### PR TITLE
templates: message flash fix

### DIFF
--- a/invenio_theme/templates/invenio_theme/macros/messages.html
+++ b/invenio_theme/templates/invenio_theme/macros/messages.html
@@ -1,20 +1,10 @@
 {%- macro flashed_messages() -%}
   {%- block messages %}
-    {%- for category, msg in get_flashed_messages(with_categories=True,
-    category_filter=['', 'info', 'danger', 'error', 'warning', 'success',
-    '(html_safe)', 'info(html_safe)', 'danger(html_safe)', 'error(html_safe)',
-    'warning(html_safe)', 'success(html_safe)']) %}
-    {%- set category = 'danger' if category == 'error'
-    else 'danger(html_safe)' if category == 'error(html_safe)' else category %}
-      <div class="alert alert-{{ category[:-('(html_safe)'|length)] if category.endswith('(html_safe)') else category }}">
+    {%- for category, msg in get_flashed_messages(with_categories=True) %}
+      {%- set category = 'info' if category not in ['info', 'danger', 'warning', 'success'] else category %}
+      <div class="alert alert-{{ category }}">
         <a class="close" data-dismiss="alert" href="#">&times;</a>
-        {%- block message %}
-        {%- if category.endswith('(html_safe)') %}
-            {{ msg|safe }}
-        {%- else %}
-            {{ msg }}
-        {%- endif %}
-        {%- endblock message %}
+          {{ msg }}
       </div>
     {%- endfor %}
   {%- endblock messages %}


### PR DESCRIPTION
* Fixes issue with message flashing not displaying the actual message.

* Sets default category to 'info'.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>