### PR TITLE
static: fix settings.js syntax error

### DIFF
--- a/invenio_theme/static/js/settings.js
+++ b/invenio_theme/static/js/settings.js
@@ -31,4 +31,4 @@ require.config({
       deps: ["jquery"]
     }
   }
-});
+})


### PR DESCRIPTION
* FIX Removes last semicolon from `settings.js` because raised
  SyntaxError while building the assets.

Signed-off-by: Harris Tzovanakis <me@drjova.com>

---

```bash
$ cds assets build
Building bundle: gen/packed.%(version)s.js
Failed, error was: requirejs: subprocess returned a non-success result code: 1, stdout=Error: Error: Build file /Users/drjova/.virtualenvs/invenio3/lib/python2.7/site-packages/invenio_theme/static/js/settings.js is malformed: SyntaxError: Unexpected token ;
    at Function.build.createConfig (/usr/local/lib/node_modules/requirejs/bin/r.js:26850:23)
```