### PR TITLE
templates: search bar in header

### DIFF
--- a/invenio_theme/ext.py
+++ b/invenio_theme/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -25,7 +25,6 @@
 """Invenio standard theme."""
 
 from __future__ import absolute_import, print_function
-
 
 from flask import Blueprint
 from flask_babelex import gettext as _
@@ -88,6 +87,8 @@ class InvenioTheme(object):
         config.setdefault(
             'SETTINGS_TEMPLATE', 'invenio_theme/page_settings.html')
         config.setdefault(
+            'HEADER_TEMPLATE', 'invenio_theme/header.html')
+        config.setdefault(
             'THEME_BASE_TEMPLATE', config['BASE_TEMPLATE'])
         config.setdefault(
             'THEME_COVER_TEMPLATE', config['COVER_TEMPLATE'])
@@ -103,3 +104,6 @@ class InvenioTheme(object):
             'THEME_404_TEMPLATE', 'invenio_theme/404.html')
         config.setdefault(
             'THEME_500_TEMPLATE', 'invenio_theme/500.html')
+
+        config.setdefault('THEME_SEARCHBAR', True)
+        config.setdefault('THEME_SEARCH_ENDPOINT', '/search')

--- a/invenio_theme/templates/invenio_theme/breadcrumbs.html
+++ b/invenio_theme/templates/invenio_theme/breadcrumbs.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -21,23 +21,23 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 #}
-{% if breadcrumbs|length > 1 %}
+{%- if breadcrumbs|length > 1 %}
 <div class="container">
   <ul class="breadcrumb" itemprop="breadcrumb">
-    {% for breadcrumb in breadcrumbs %}
-    {% if loop.last %}
+    {%- for breadcrumb in breadcrumbs %}
+    {%- if loop.last %}
     <li class="active">
       {{ breadcrumb.text|safe }}
     </li>
-    {% else %}
+    {%- else %}
     <li>
       <a href="{{ breadcrumb.url }}"
          class="navtrail">
         {{ breadcrumb.text|safe }}
       </a>
     </li>
-    {% endif %}
-    {% endfor %}
+    {%- endif %}
+    {%- endfor %}
   </ul>
 </div>
-{% endif %}
+{%- endif %}

--- a/invenio_theme/templates/invenio_theme/header.html
+++ b/invenio_theme/templates/invenio_theme/header.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -44,20 +44,34 @@
       {%- endblock navbar_header %}
       {%- block navbar_inner %}
       <div id="navbar" class="navbar-collapse collapse">
-        {% block navbar_nav %}
+        {%- block navbar_nav %}
+        {%- if config['THEME_SEARCHBAR'] %}
+        {%- block navbar_search %}
+        <form class="navbar-form navbar-left" action="{{config.THEME_SEARCH_ENDPOINT}}" role="search">
+          <div class="form-group">
+            <div class="input-group">
+              <input type="text" class="form-control" name="q" placeholder="{{_('Search')}}">
+              <div class="input-group-btn">
+                <button type="submit" class="btn btn-default"><i class="fa fa-search"></i></button>
+              </div>
+            </div>
+          </div>
+        </form>
+        {%- endblock navbar_search %}
+        {%- endif %}
         <ul class="nav navbar-nav">
           {%- for item in current_menu.submenu('main').children|sort(attribute='order') if item.visible recursive %}
-          {%- if item.children -%}
+          {%- if item.children %}
           <li class="dropdown{{ ' active' if item.active else ''}}">
             <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" href="{{ item.url }}">{{ item.text|safe }} <b class="caret"></b></a>
             <ul class="dropdown-menu">{{ loop(item.children|sort(attribute='order')) }}</ul>
           </li>
-          {%- else -%}
+          {%- else %}
             <li{{ ' class="active"'|safe if item.active and loop.depth == 1 else '' }}><a href="{{ item.url }}">{{ item.text|safe }}</a></li>
           {%- endif %}
           {%- endfor %}
         </ul>
-        {% endblock navbar_nav %}
+        {%- endblock navbar_nav %}
         {%- block navbar_right %}
 {%- include "invenio_theme/header_login.html" %}
         {%- endblock navbar_right %}

--- a/invenio_theme/templates/invenio_theme/page.html
+++ b/invenio_theme/templates/invenio_theme/page.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -76,6 +76,7 @@
       <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
     {%- endblock browserupgrade %}
+    {%- block body_inner %}
     {%- block page_header %}
 {% include "invenio_theme/header.html" %}
     {%- endblock page_header %}
@@ -85,6 +86,7 @@
     {%- block page_footer %}
 {% include "invenio_theme/footer.html" %}
     {%- endblock page_footer %}
+    {%- endblock body_inner %}
     {%- block javascript %}
 {% include "invenio_theme/javascript.html" %}
     {%- endblock javascript %}

--- a/tests/test_invenio_theme.py
+++ b/tests/test_invenio_theme.py
@@ -97,7 +97,7 @@ def test_page_template_blocks(app):
     blocks = [
         'head', 'head_meta', 'head_title', 'head_links', 'head_links_langs',
         'head_apple_icons', 'header', 'body', 'browserupgrade', 'page_header',
-        'page_body', 'page_footer', 'trackingcode',
+        'page_body', 'page_footer', 'trackingcode', 'body_inner'
     ]
     InvenioTheme(app)
     InvenioAssets(app)
@@ -117,7 +117,7 @@ def test_cover_template_blocks(app):
 
     # Test template API
     blocks = [
-        'panel', 'page_header', 'page_body', 'page_footer', 'panel_content'
+        'panel', 'page_header', 'page_body', 'page_footer', 'panel_content',
     ]
     InvenioTheme(app)
     InvenioAssets(app)
@@ -149,9 +149,16 @@ def test_header_template_blocks(app):
     """Test template blokcs in header.html."""
     blocks = [
         'navbar', 'navbar_header', 'brand', 'navbar_inner', 'navbar_right',
-        'breadcrumbs', 'flashmessages', 'navbar_nav',
+        'breadcrumbs', 'flashmessages', 'navbar_nav', 'navbar_search',
     ]
     InvenioTheme(app)
     InvenioAssets(app)
     with app.test_request_context():
         assert_template_blocks("invenio_theme/header.html", blocks)
+
+    app.config.update(dict(THEME_SEARCHBAR=False))
+    with app.test_request_context():
+        tpl = \
+            r'{% extends "invenio_theme/header.html" %}' \
+            r'{% block navbar_search %}TPLTEST{% endblock %}'
+        assert 'TPLTEST' not in render_template_string(tpl)


### PR DESCRIPTION
* Adds search bar in header. (closes #35)

* Adds template blocks to page and header templates for better
  customization.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>