### PR TITLE
templates: allow no logo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,13 +27,14 @@ from __future__ import print_function
 import os
 
 import sphinx.environment
-from docutils.utils import get_source_line
+
+_warn_node_old = sphinx.environment.BuildEnvironment.warn_node
 
 
-def _warn_node(self, msg, node):
+def _warn_node(self, msg, *args, **kwargs):
     """Do not warn on external images."""
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+        _warn_node_old(self, msg, *args, **kwargs)
 
 sphinx.environment.BuildEnvironment.warn_node = _warn_node
 

--- a/invenio_theme/templates/invenio_theme/page_cover.html
+++ b/invenio_theme/templates/invenio_theme/page_cover.html
@@ -43,7 +43,17 @@
     <div class="row">
       <div class="col-md-6 col-md-offset-3">
         {%- block brand %}
-        <a href="/"><img class="text-center masthead-brand" src="{{ url_for('static', filename=config.THEME_LOGO)}}" alt="{{_(config.THEME_SITENAME)}}" width="250px"/></a>
+          {%- if config.THEME_LOGO %}
+            <a href="/">
+              <img class="text-center masthead-brand"
+                   src="{{ url_for('static', filename=config.THEME_LOGO)}}"
+                   alt="{{ _(config.THEME_SITENAME) }}" width="250px"/>
+            </a>
+          {%- elif config.THEME_SITENAME %}
+            <a href="/" class="text-center masthead-brand">
+              {{ _(config.THEME_SITENAME) }}
+            </a>
+          {% endif %}
         {%- endblock %}
       </div>
     </div>


### PR DESCRIPTION
* FIX Fixes issue when `THEME_LOGO` was set to `None` (closes #48).