### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio Theme.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-theme
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/invenio_theme/translations/da/LC_MESSAGES/messages.po
+++ b/invenio_theme/translations/da/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version:  invenio-theme\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-12-01 13:27+0100\n"
 "PO-Revision-Date: 2015-10-10 11:03+0000\n"
 "Last-Translator: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ directory = invenio_theme/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_theme/translations/messages.pot
 

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
     keywords='invenio',
     license='GPLv2',
     author='Invenio Collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-theme',
     packages=packages,
     zip_safe=False,


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>