### PR TITLE
templates: fix of html lang attribute

### DIFF
--- a/invenio_theme/templates/invenio_theme/page.html
+++ b/invenio_theme/templates/invenio_theme/page.html
@@ -22,7 +22,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 #}
 <!DOCTYPE html>
-<html{% if html_css_classes %} class="{{ html_css_classes|join(' ') }}"{% endif %}{%- if g.ln %} lang="{{ g.ln|safe }}"{% endif %} dir="{{ current_i18n.locale.text_direction }}">
+<html{% if html_css_classes %} class="{{ html_css_classes|join(' ') }}"{% endif %} lang="{{ current_i18n.locale.language|safe }}" dir="{{ current_i18n.locale.text_direction }}">
   <head>
     {%- block head %}
     {%- block head_meta %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,9 @@ from invenio_theme import InvenioTheme
 def app():
     """Flask app fixture."""
     app = Flask('myapp')
+    app.config.update(
+        I18N_LANGUAGES=[('en', 'English'), ('de', 'German')],
+    )
     Babel(app)
     InvenioI18N(app)
     return app

--- a/tests/test_invenio_theme.py
+++ b/tests/test_invenio_theme.py
@@ -173,3 +173,29 @@ def test_lazy_bundles(app):
         from invenio_theme.bundles import admin_lte_css, lazy_skin
 
         assert str(lazy_skin()) in admin_lte_css.contents
+
+
+def test_html_lang(app):
+    """Test HTML language attribute."""
+    base_tpl = r"""{% extends 'invenio_theme/page.html' %}
+    {% block css %}{% endblock %}
+    {% block javascript %}{% endblock %}
+    """
+
+    @app.route('/index')
+    def index():
+        """Render default page."""
+        return render_template_string(base_tpl)
+
+    InvenioTheme(app)
+    InvenioAssets(app)
+
+    with app.test_client() as client:
+        response = client.get('/index')
+        assert b'lang="en" ' in response.data
+
+        response = client.get('/index?ln=de')
+        assert b'lang="de" ' in response.data
+
+        response = client.get('/index?ln=en')
+        assert b'lang="en" ' in response.data


### PR DESCRIPTION
* Uses `i18n.locale.language` instead of `g.ln` for `<html lang="...">`.
  (closes #73)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>