### PR TITLE
templates: invisible powered by text fix

### DIFF
--- a/invenio_theme/templates/invenio_theme/footer.html
+++ b/invenio_theme/templates/invenio_theme/footer.html
@@ -27,12 +27,12 @@
       <div class="col-xs-12"><hr /></div>
     </div>
     <div class="row">
-      {% if config.I18N_LANGUAGES %}
       <div class="col-xs-6 col-xs-push-6" style="text-align: right;">
+        {%- if config.I18N_LANGUAGES %}
         {% from "invenio_i18n/macros/language_selector.html" import language_selector_dropdown %}
         {{ language_selector_dropdown() }}
+        {%- endif %}
       </div>
-      {% endif %}
       <div class="col-xs-6 col-xs-pull-6">
         {% trans link="http://inveniosoftware.org" %}Powered by <a href="{{link}}">Invenio</a>{% endtrans %}
       </div>


### PR DESCRIPTION
* Fixes issue with "Powered by Invenio" not being visible due to the
  column being pull off the screen for single language sites.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>