### PR TITLE
remove fixme and simplify tests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,9 @@ author = u'Invenio Collaboration'
 
 # Get the version string. Cannot be done with import!
 g = {}
-with open(os.path.join('..', 'invenio_theme', 'version.py'), 'rt') as fp:
+with open(os.path.join(os.path.dirname(__file__), '..',
+                       'invenio_theme', 'version.py'),
+          'rt') as fp:
     exec(fp.read(), g)
     version = g['__version__']
 

--- a/invenio_theme/bundles.py
+++ b/invenio_theme/bundles.py
@@ -97,8 +97,6 @@ admin_css = NpmBundle(
 )
 """Default style for admin interface."""
 
-# FIXME: This bundle doesn't build without the output
-# being added to the js/base.js bundle.
 js = Bundle(
     NpmBundle(
         'node_modules/almond/almond.js',
@@ -113,7 +111,6 @@ js = Bundle(
     Bundle(
         'js/base.js',
         filters='requirejs',
-        output='gen/base.%(version)s.js',
     ),
     filters='jsmin',
     output='gen/packed.%(version)s.js',

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,4 +23,5 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --pep8 --ignore=docs --cov=invenio_theme --cov-report=term-missing
+pep8ignore = docs/conf.py ALL
+addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=invenio_theme --cov-report=term-missing docs tests invenio_theme

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -27,5 +27,4 @@ pydocstyle invenio_theme && \
 # isort -rc -c -df **/*.py && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test && \
-sphinx-build -qnNW -b doctest docs docs/_build/doctest
+python setup.py test


### PR DESCRIPTION
* Removes unnecessary output parameter from js Bundle. (closes #89)

* doctests are now executed with pytest instead of sphinx. (closes #99)