### PR TITLE
webpack: npm vulnerabilities warning

### DIFF
--- a/invenio_theme/webpack.py
+++ b/invenio_theme/webpack.py
@@ -38,5 +38,6 @@ theme = WebpackBundle(
         'moment': '~2.23.0',
         'select2': '~4.0.2',
         'admin-lte': '~2.4.8',
+        'morris.js': 'github:morrisjs/morris.js',
     }
 )


### PR DESCRIPTION
`morris.js` has a vulnerability ([https://www.npmjs.com/advisories/307](https://www.npmjs.com/advisories/307)) to cross-site scripting which is fixed in `master` but not included in any release.

The last release was 4 years ago so this fix uses the latest version in `master`.

Fixes inveniosoftware/cookiecutter-invenio-instance#100.