### PR TITLE
header_login: change sign-up icon

### DIFF
--- a/invenio_theme/templates/semantic-ui/invenio_theme/header_login.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/header_login.html
@@ -17,8 +17,7 @@
         <a href="{{ url_for_security('register') }}" type="submit"
            class="ui button orange">
           <i class="icons">
-            <i class="user icon"></i>
-            <i class="corner add icon"></i>
+            <i class="edit outline icon"></i>
           </i> {{ _('Sign up') }}
         </a>{% endif %}
     </form>


### PR DESCRIPTION
Changes sign's up button icon from:
<img width="369" alt="Screenshot 2020-05-28 at 14 55 39" src="https://user-images.githubusercontent.com/22594783/83146497-afcbf600-a0f6-11ea-9566-b583089d1b78.png">

to

<img width="404" alt="Screenshot 2020-05-28 at 15 02 32" src="https://user-images.githubusercontent.com/22594783/83146515-b6f30400-a0f6-11ea-94fe-44a90b8632ab.png">
