### PR TITLE
breadcrumbs: style breadcrumbs in profile page

### DIFF
--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/header.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/header.overrides
@@ -9,3 +9,7 @@
 .ui.login.segment {
     padding: 15px 40px 40px 40px;
 }
+
+.theme.header {
+    margin-bottom: 20px;
+}

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/segment.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/segment.overrides
@@ -1,0 +1,4 @@
+.ui.breadcrumbs.segment {
+    border: none;
+    box-shadow: none;
+}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/breadcrumbs.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/breadcrumbs.html
@@ -7,22 +7,20 @@
   under the terms of the MIT License; see LICENSE file for more details.
 #}
 {%- if breadcrumbs|length > 1 %}
-  <div class="ui grid container">
-    <div class="row">
-      <div class="ui large breadcrumb" itemprop="breadcrumb">
-        {%- for breadcrumb in breadcrumbs %}
-          {%- if loop.last %}
-            <a class="active section">
-              {{ breadcrumb.text|safe }}
-            </a>
-          {%- else %}
-            <a href="{{ breadcrumb.url }}" class="section">
-              {{ breadcrumb.text|safe }}
-            </a>
-            <span class="divider">/</span>
-          {%- endif %}
-        {%- endfor %}
-      </div>
+  <div class="ui breadcrumbs segment secondary container">
+    <div class="ui large breadcrumb" itemprop="breadcrumb">
+      {%- for breadcrumb in breadcrumbs %}
+        {%- if loop.last %}
+          <a class="active section">
+            {{ breadcrumb.text|safe }}
+          </a>
+        {%- else %}
+          <a href="{{ breadcrumb.url }}" class="section">
+            {{ breadcrumb.text|safe }}
+          </a>
+          <span class="divider">/</span>
+        {%- endif %}
+      {%- endfor %}
     </div>
   </div>
 {%- endif %}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/header.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/header.html
@@ -8,7 +8,7 @@
 #}
 
 
-<header>
+<header class="theme header">
 
   {%- block navbar %}
     <nav class="ui inverted menu borderless">


### PR DESCRIPTION
Breadcrumbs before

<img width="1674" alt="Screenshot 2020-06-18 at 15 04 39" src="https://user-images.githubusercontent.com/22594783/85024182-09fc2c00-b176-11ea-9275-83d5e615ca6f.png">

and after

<img width="1673" alt="Screenshot 2020-06-18 at 15 07 50" src="https://user-images.githubusercontent.com/22594783/85024194-11bbd080-b176-11ea-85d0-6d74830908a6.png">
