### PR TITLE
ui: truncate long email addresses

### DIFF
--- a/invenio_theme/templates/semantic-ui/invenio_theme/header_login.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/header_login.html
@@ -27,7 +27,7 @@
       <div class="ui buttons">
         <a class="ui button"
            href="{{ url_for('invenio_userprofiles.profile') }}">
-          <i class="user icon"></i> {{ current_user.email }}
+          <i class="user icon"></i> {{ current_user.email|truncate(31,true) }}
         </a>
 
         <div class="ui dropdown icon button">


### PR DESCRIPTION
<img width="1423" alt="Screen Shot 2020-10-26 at 11 06 31 AM" src="https://user-images.githubusercontent.com/4917492/97160275-6272b400-177c-11eb-907a-5f887fba0484.png">

The length is truncated to 31 characters to fit 95% of the emails according to this article: https://www.freshaddress.com/blog/long-email-addresses/

EDIT
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/267