### PR TITLE
config: add base header variable

### DIFF
--- a/invenio_theme/config.py
+++ b/invenio_theme/config.py
@@ -19,6 +19,10 @@ facing templates usually extends from this template and thus changing this
 template allows to change design and layout of Invenio.
 """
 
+HEADER_TEMPLATE = 'invenio_theme/header.html'
+"""Base header template to be extended on custom headers."""
+
+
 ADMIN_BASE_TEMPLATE = 'invenio_theme/page_admin.html'
 """Base template for the administration interface.
 


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-search-ui/issues/83

The `HEADER_TEMPLATE` variable needs to be defined somewhere to fix the issue. Why here? Because the default value is `invenio_theme/header.html`. 

The issue raises from `invenio-search-ui`, which only defines it in tests (see [here](https://github.com/inveniosoftware/invenio-search-ui/blob/7556f8f6a97fb9831664d02b061c9ea6b7068936/tests/conftest.py#L43)). The referenced template is a mere mock one, so it cannot be referenced in the `config.py`. `invenio-search-ui` defines a `header.html` template, but it extends `HEADER_TEMPLATE` (setting this to the value would cause infinite recursion). Then it would set the default value [here](https://github.com/inveniosoftware/invenio-search-ui/blob/2fecd7a89dfd99235908c7a722ad6d31e17e0d79/invenio_search_ui/ext.py#L46)


Ideally, I'd say other modules should inherit from `THEME_HEADER_TEMPLATE`... But changing this across modules would be quite consuming.

**Question**

Invenio Search UI does not depend on Invenio Theme, but it assumes that those base templates exist somehow. This is also the case for many other variables in that module (e.g. `BASE_TEMPLATE`), so I would say is ok.