### PR TITLE
webpack: change less alias to follow conventions

### DIFF
--- a/invenio_theme/webpack.py
+++ b/invenio_theme/webpack.py
@@ -71,7 +71,7 @@ theme = WebpackThemeBundle(
                 '@js/invenio_theme': 'js/invenio_theme',
                 # TODO: change to "@less/invenio_theme":
                 #   https://github.com/inveniosoftware/invenio-theme/issues/200
-                '@invenio_theme/less': 'less/invenio_theme',
+                '@less/invenio_theme': 'less/invenio_theme',
                 # Used for defining an 'invenio' theme for Semantic-UI. The
                 # code in "Semantic-UI-Less/theme.less" will look for e.g.
                 # themes/@{theme}/globals/site.variables". This will resolve


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-theme/issues/200

Changed alias. Currently evaluating the implications:

- Cookiecutter Invenio Instance. Checked the code and there is no reference to the alias (did a grep also and nothing). Bootstrapped and instance and seems to be working. See ss below, it can be seen is OK and it also has semantic UI classes.

![Screenshot 2020-12-02 at 16 23 16](https://user-images.githubusercontent.com/6756943/100892505-b0d14c00-34ba-11eb-863d-ec4cffbf3e7a.png)

- Cookiecutter Invenio RDM, same procedure as above
![Screenshot 2020-12-02 at 16 44 46](https://user-images.githubusercontent.com/6756943/100895362-c136f600-34bd-11eb-9e37-86aff7b79ef5.png)
