### PR TITLE
Brand menu

### DIFF
--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/collections/menu.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/collections/menu.overrides
@@ -2,14 +2,8 @@
          Site Overrides
 *******************************/
 
-.ui.inverted.menu{
-  background: @brandColor;
+.ui.inverted.menu {
   border-radius: 0px;
-}
-
-.ui.vertical.menu .active.item {
-    background: @primaryColor;
-    pointer-events: none;
 }
 
 .ui.vertical.menu .item i.icon {
@@ -17,10 +11,22 @@
     margin-right: 0.5em;
 }
 
-.ui.menu .blue.active.item {
-    color: white !important;
+/* Brand */
+.ui.inverted.menu .brand.active.item,
+.ui.inverted.brand.menu {
+  background-color: @brandColor;
+}
+.ui.inverted.brand.menu .item:before {
+  background-color: @invertedColoredDividerBackground;
+}
+.ui.inverted.brand.menu .active.item {
+  background-color: @invertedColoredActiveBackground !important;
 }
 
-.ui.vertical.menu .active.item:hover {
-    background-color: @primaryColor;
+.ui.menu .brand.active.item,
+.ui.brand.menu .active.item {
+  border-color: @brandColor !important;
+  background-color: @brandColor;
+  color: @white !important;
+  pointer-events: none;
 }

--- a/invenio_theme/templates/semantic-ui/invenio_theme/header.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/header.html
@@ -12,7 +12,7 @@
   <div class="outer-navbar">
 
   {%- block navbar %}
-  <nav id="invenio-nav" class="ui inverted menu borderless">
+  <nav id="invenio-nav" class="ui inverted brand menu borderless">
     <div class="ui grid container">
       <ul class="navbar-menu">
         <li class="logo">

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
@@ -17,7 +17,7 @@
         <strong class="header item">{{ _('Settings') }}</strong>
         {%- for item in current_menu.submenu('settings').children if item.visible %}
         {%- block settings_menu_item scoped %}
-          <a href="{{ item.url }}" class="item{% if item.active %} blue inverted active{% endif %}">
+          <a href="{{ item.url }}" class="brand item{% if item.active %} active{% endif %}">
             {{ item.text|safe }}
           </a>
         {%- endblock %}


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/512

<img width="298" alt="Screenshot 2021-02-03 at 15 04 22" src="https://user-images.githubusercontent.com/22594783/106757844-1fed2d00-6631-11eb-8787-3e7eb2333c13.png">

Now menu is also controlled by `brand` class and can easily change if the `@brandColor` is set to a different color e.g `purple`. With that change the UI becomes

<img width="1181" alt="Screenshot 2021-02-03 at 15 01 50" src="https://user-images.githubusercontent.com/22594783/106758020-5165f880-6631-11eb-9f3d-627f84aee301.png">
<img width="908" alt="Screenshot 2021-02-03 at 15 02 01" src="https://user-images.githubusercontent.com/22594783/106758027-532fbc00-6631-11eb-8432-1a6eef6bde4a.png">
