### PR TITLE
webpack: bump admin-lte dependency

### DIFF
--- a/invenio_theme/assets/semantic-ui/scss/invenio_theme/admin.scss
+++ b/invenio_theme/assets/semantic-ui/scss/invenio_theme/admin.scss
@@ -6,8 +6,7 @@
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
-@import "~admin-lte/dist/css/AdminLTE";
-@import "~admin-lte/dist/css/skins/skin-blue";
+@import "~admin-lte/dist/css/adminlte";
 @import "~select2/dist/css/select2";
 
 .main-header {

--- a/invenio_theme/version.py
+++ b/invenio_theme/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.3.9'
+__version__ = '1.3.10'

--- a/invenio_theme/webpack.py
+++ b/invenio_theme/webpack.py
@@ -69,7 +69,7 @@ theme = WebpackThemeBundle(
                 'font-awesome': '~4.4.0',
                 'jquery': '~3.2.1',
                 'select2': '~4.0.2',
-                'admin-lte': '~2.4.8',
+                'admin-lte': '~3.1.0',
             },
             aliases={
                 '@js/invenio_theme': 'js/invenio_theme',


### PR DESCRIPTION
- part of closing https://github.com/inveniosoftware/invenio-app-rdm/issues/956
- See commit message for more details (+ link to differences in this folder which is relevant: https://github.com/ColorlibHQ/AdminLTE/tree/v3.1.0/dist/css)
- webpack: bump admin-lte in semantic-ui for security
- release: v1.3.10
