### PR TITLE
A11y landmarks

### DIFF
--- a/invenio_theme/templates/semantic-ui/invenio_theme/page.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page.html
@@ -55,7 +55,7 @@
     {%- endblock head %}
   </head>
 
-  <body ng-csp {% if body_css_classes %} class="{{ body_css_classes|join(' ') }}"{% endif %}{% if g.ln %} lang="{{ g.ln.split('_', 1)[0]|safe }}"{% if rtl_direction %} {{ rtl_direction|safe }}{% endif %}{% endif %} itemscope itemtype="http://schema.org/WebPage" data-spy="scroll" data-target=".scrollspy-target">
+  <body{% if body_css_classes %} class="{{ body_css_classes|join(' ') }}"{% endif %}{% if g.ln %} lang="{{ g.ln.split('_', 1)[0]|safe }}"{% if rtl_direction %} {{ rtl_direction|safe }}{% endif %}{% endif %} itemscope itemtype="http://schema.org/WebPage" data-spy="scroll" data-target=".scrollspy-target">
     {%- block body %}
     {%- block browserupgrade %}
     <!--[if lt IE 8]>

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2018 CERN.
+  Copyright (C) 2021 New York University.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page_error.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page_error.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2018 CERN.
+  Copyright (C) 2021 New York University.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -10,12 +11,12 @@
 {% extends config.THEME_BASE_TEMPLATE %}
 
 {% block page_body %}
-<div class="ui grid container error-page">
+<main id="main" class="ui grid container error-page">
 <div class="ui divider hidden"></div>
   <div class="row">
     <div class="column">
       {% block message %}{% endblock message %}
     </div>
   </div>
-</div>
+</main>
 {% endblock %}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
@@ -11,7 +11,7 @@
 
 {%- block page_body scoped %}
 <div class="ui grid container stackable">
-  <div class="four wide column">
+  <nav class="four wide column" aria-label="Account settings">
     {%- block settings_menu scoped %}
       <div class="ui vertical menu fluid">
         <strong class="header item">{{ _('Settings') }}</strong>
@@ -24,8 +24,8 @@
         {%- endfor %}
       </div>
     {%- endblock %}
-  </div>
-  <div class="twelve wide column">
+  </nav>
+  <main class="twelve wide column" id="main">
     {%- block settings_content scoped %}
     <div class="ui segments">
       <div class="ui segment secondary">
@@ -48,6 +48,6 @@
     </div>
     {%- endblock %}
 
-  </div>
+  </main>
 </div>
 {%- endblock %}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
@@ -12,7 +12,7 @@
 
 {%- block page_body scoped %}
 <div class="ui grid container stackable">
-  <nav class="four wide column" aria-label="Account settings">
+  <nav class="four wide column" aria-label="{{ _('Account settings') }}">
     {%- block settings_menu scoped %}
       <div class="ui vertical menu fluid">
         <strong class="header item">{{ _('Settings') }}</strong>

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2018 CERN.
+  Copyright (C) 2021 New York University.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.


### PR DESCRIPTION
- Added "main" landmarks to two templates (including an "id", which will be useful for "skip to content" links)
- Removed " ng-csp" from body tag