### PR TITLE
Darken "text-muted," globally

### DIFF
--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
@@ -62,7 +62,7 @@ li ~ .item{
 }
 
 .text-muted{
-  color: #6e6c6c;
+  color: #757575;
 }
 
 .inline-block {

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
@@ -62,7 +62,7 @@ li ~ .item{
 }
 
 .text-muted{
-  color: #777;
+  color: #6e6c6c;
 }
 
 .inline-block {


### PR DESCRIPTION
With #757575 and a white background, the contrast ratio is now 4.6:1, which is WCAG 2.0 level AA compliant