### PR TITLE
messages: announce alert message to screen readers

### DIFF
--- a/invenio_theme/assets/semantic-ui/js/invenio_theme/theme.js
+++ b/invenio_theme/assets/semantic-ui/js/invenio_theme/theme.js
@@ -1,6 +1,6 @@
 /*
  * This file is part of Invenio.
- * Copyright (C) 2017-2020 CERN.
+ * Copyright (C) 2017-2022 CERN.
  *
  * Invenio is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
@@ -44,4 +44,9 @@ function toggleMenu() {
     menu.classList.add("active");
   }
 }
-toggle.addEventListener("click", toggleMenu, false);
+toggle && toggle.addEventListener("click", toggleMenu, false);
+
+// Make sure screen reader picks up the flashed messages on page load
+document.addEventListener('DOMContentLoaded', event => {
+  jquery("#flash-message #alert-content").css('display', 'block');
+})

--- a/invenio_theme/templates/semantic-ui/invenio_theme/macros/messages.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/macros/messages.html
@@ -25,12 +25,12 @@
       <div class="ui {{ category }} flashed message">
         <div class="ui grid {{gridClass}}">
 
-          <div class="{{ firstColWidth }} left aligned column">
-            <p>{{ msg }}</p>
+          <div role="alert" id="flash-message" class="{{ firstColWidth }} left aligned column">
+            <p id="alert-content" style="display:none;">{{ msg }}</p>
           </div>
 
           <div class="{{ secondColWidth }} right aligned column">
-            <button class="iconhold close-btn" aria-label="{{_('Close') }}">
+            <button class="ui icon button iconhold close-btn" aria-label="{{_('Close') }}">
               <i class="flashed close icon"></i>
             </button>
           </div>

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page_cover.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page_cover.html
@@ -61,4 +61,8 @@
     {% block page_footer %}
     {% endblock page_footer %}
   </div>
+
+  {%- block javascript %}
+    {{ webpack['theme.js']}}
+  {%- endblock javascript %}
 {%- endblock body %}


### PR DESCRIPTION
- Add `role="alert"` and `display:none;` to message-wrapper. 
- Replace `display:none;` with `display:block;` on page load to trigger the announcement by the screen reader.

Closes [#1191](https://github.com/inveniosoftware/invenio-app-rdm/issues/1191)