### PR TITLE
i18n: include translation files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -28,4 +28,5 @@ recursive-include invenio_theme *.svg
 recursive-include invenio_theme *.variables
 recursive-include invenio_theme *.woff
 recursive-include invenio_theme *.woff2
+recursive-include invenio_theme *.po *.pot *.mo
 recursive-include tests *.py


### PR DESCRIPTION
if this is not present the `.mo` extension files will not be added to the package creation.
closes #260 