### PR TITLE
cover page: make flash message span full width

### DIFF
--- a/invenio_theme/templates/semantic-ui/invenio_theme/macros/messages.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/macros/messages.html
@@ -6,20 +6,35 @@
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
 #}
-{%- macro flashed_messages() -%}
-  {%- block messages %}
-    {%- for category, msg in get_flashed_messages(with_categories=True) %}
+{%- macro flashed_messages(center_text=false) -%}
+
+  {%- block messages scoped %}
+  {%- for category, msg in get_flashed_messages(with_categories=True) %}
       {%- set category = 'info' if category not in ['info', 'error', 'warning', 'success'] else category %}
+
+      {%- set gridClass = 'container' %}
+      {%- set firstColWidth = 'fourteen wide' %}
+      {%- set secondColWidth = 'two wide' %}
+
+      {%- if center_text %}
+        {%- set gridClass = 'centered' %}
+        {%- set firstColWidth = 'twelve wide mobile six wide tablet four wide computer' %}
+        {%- set secondColWidth = 'two wide tablet one wide computer' %}
+      {% endif %}
+
       <div class="ui {{ category }} flashed message">
-        <div class="ui grid container">
-          <div class="fourteen wide left aligned column">
+        <div class="ui grid {{gridClass}}">
+
+          <div class="{{ firstColWidth }} left aligned column">
             <p>{{ msg }}</p>
           </div>
-          <div class="two wide right aligned column">
+
+          <div class="{{ secondColWidth }} right aligned column">
             <button class="iconhold close-btn" aria-label="{{_('Close') }}">
               <i class="flashed close icon"></i>
             </button>
           </div>
+
         </div>
       </div>
     {%- endfor %}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page_cover.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page_cover.html
@@ -12,46 +12,52 @@
 {%- set body_css_classes=['ui grid doubling middle center aligned cover-page'] %}
 
 {%- block body %}
-  <div class="column centered">
+  <div class="sixteen wide column centered">
     {%- block flashmessages %}
       {%- from "invenio_theme/macros/messages.html" import flashed_messages with context -%}
-      {{ flashed_messages() }}
+      {{ flashed_messages(center_text=true) }}
     {%- endblock flashmessages %}
-    {% block page_header %}
-      <div class="ui basic very padded segment">
-        {%- block brand %}
-          {%- if config.THEME_LOGO %}
-            <a href="/">
-              <img class="ui centered medium image"
-                   src="{{ url_for('static', filename=config.THEME_LOGO) }}"
-                   alt="{{ _(config.THEME_SITENAME) }}"/>
-            </a>
-          {%- elif config.THEME_SITENAME %}
-            <a href="/" class="text-center">
-              {{ _(config.THEME_SITENAME) }}
-            </a>
-          {% endif %}
-        {%- endblock brand %}
-      </div>
-    {% endblock page_header %}
-    {%- block page_body %}
-      <div class="container">
-        <div class="row panel-container">
-          {% block panel %}
-            <div class="column three wide"></div>
-            <div class="column six wide">
-              <div class="panel panel-default">
-                <div class="panel-body">
-                  {% block panel_content %}
-                    <h3 class="centered panel-free-title">{{ panel_title }}</h3>
-                  {% endblock panel_content %}
+
+    <div class="ui grid">
+      <div class="fourteen wide mobile eight wide tablet five wide computer centered column">
+        {% block page_header %}
+          <div class="ui basic very padded segment">
+            {%- block brand %}
+              {%- if config.THEME_LOGO %}
+                <a href="/">
+                  <img class="ui centered medium image"
+                      src="{{ url_for('static', filename=config.THEME_LOGO) }}"
+                      alt="{{ _(config.THEME_SITENAME) }}"/>
+                </a>
+              {%- elif config.THEME_SITENAME %}
+                <a href="/" class="text-center">
+                  {{ _(config.THEME_SITENAME) }}
+                </a>
+              {% endif %}
+            {%- endblock brand %}
+          </div>
+        {% endblock page_header %}
+
+        {%- block page_body %}
+          <div class="container">
+            <div class="row panel-container">
+              {% block panel %}
+                <div class="column three wide"></div>
+                <div class="column six wide">
+                  <div class="panel panel-default">
+                    <div class="panel-body">
+                      {% block panel_content %}
+                        <h3 class="centered panel-free-title">{{ panel_title }}</h3>
+                      {% endblock panel_content %}
+                    </div>
+                  </div>
                 </div>
-              </div>
+              {% endblock panel %}
             </div>
-          {% endblock panel %}
-        </div>
+          </div>
+        {%- endblock page_body %}
       </div>
-    {%- endblock page_body %}
+    </div>
     {% block page_footer %}
     {% endblock page_footer %}
   </div>


### PR DESCRIPTION
Closes [#143](https://github.com/inveniosoftware/invenio-app-rdm/issues/143)

- Changed grid layout to span full width and adjusted the col-widths for the flash message if centered
- Changed the layout for the page_cover-template to use the default semantic-ui columns instead of `.column.centered` overwritten in `site.overrides` with `width: 33% !important;` + media queries. ([`/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides`](https://github.com/inveniosoftware/invenio-theme/blob/master/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides#L25)). This to make sure the text aligns with the segment below.

__Note:__ The script that enables dismissing the message is added in [#253](https://github.com/inveniosoftware/invenio-theme/pull/253).

### Screenshots

__Desktop__
<img width="1368" alt="Screenshot 2022-02-18 at 14 06 29" src="https://user-images.githubusercontent.com/21052053/154694518-18d5759f-105f-44c0-b6f6-d7a8f8e6e80a.png">

__Tablet__
<img width="869" alt="Screenshot 2022-02-18 at 14 46 21" src="https://user-images.githubusercontent.com/21052053/154694561-ad804efa-5149-4c66-8a26-be02e2be6d44.png">

__Mobile__
<img width="452" alt="Screenshot 2022-02-18 at 14 46 30" src="https://user-images.githubusercontent.com/21052053/154694576-f2c06bb3-16fe-4bf8-aef2-752adb58f0ce.png">

