### PR TITLE
Bypass links: allow keyboard-only users to skip navigation

### DIFF
--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
@@ -190,3 +190,11 @@ code {
 }
 
 .generate-truncate-classes(5);
+
+.skip-link {
+  position: absolute;
+  z-index: -999;
+  &:focus {
+    z-index: 999;
+  }
+}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page.html
@@ -71,6 +71,10 @@
 
     {%- block body %}
 
+      {%- block bypasslinks %}
+      <a id="skip-to-main" class="ui button primary ml-5 mt-5 skip-link" href="#main">{{_('Skip to main')}}</a>
+      {%- endblock bypasslinks %}
+
       {%- block browserupgrade %}
       <!--[if lt IE 8]>
         <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>


### PR DESCRIPTION
### Description

* Adds new block to all pages for a bypass link
* Adds CSS to hide the block except when it's focused

closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1171

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
