### PR TITLE
theme: add accessibility to ui-accordions

### DIFF
--- a/invenio_theme/assets/semantic-ui/js/invenio_theme/theme.js
+++ b/invenio_theme/assets/semantic-ui/js/invenio_theme/theme.js
@@ -14,7 +14,42 @@ import "semantic-ui-less/semantic.less";
 
 // Initialize Semantic UI components
 jquery(".ui.dropdown").dropdown();
-jquery(".ui.accordion").accordion();
+
+jquery(".ui.accordion").accordion({
+  selector: {
+    trigger: '.trigger'
+  },
+  onOpening: function() {
+    const $accordionTrigger = this.closest('.ui.accordion').find('.trigger');
+    const accordionCloseText = $accordionTrigger.attr('data-close-text');
+    accordionCloseText && $accordionTrigger.html(accordionCloseText);
+    $accordionTrigger.attr('aria-expanded', true);
+  },
+  onClosing: function() {
+    const $accordionTrigger = this.closest('.ui.accordion').find('.trigger');
+    const accordionOpenText = $accordionTrigger.attr('data-open-text');
+    accordionOpenText && $accordionTrigger.html(accordionOpenText);
+    $accordionTrigger.attr('aria-expanded', false);
+  }
+});
+
+jquery('.ui.accordion .trigger').on("keydown", function (event) {
+  const $target = jquery(event.target);
+  const isTriggerElement = $target.is(".trigger") && !$target.is('button');
+  // Button already have this functionality and will cause double trigger
+
+  if (isTriggerElement && event.key === "Enter") {
+    const accordionTitle = jquery(event.target).closest('.title');
+
+    if (accordionTitle.hasClass('active')) {
+      $target.accordion("close");
+      $target.attr('aria-expanded', false);
+    } else {
+      $target.accordion("open");
+      $target.attr('aria-expanded', true);
+    }
+  }
+});
 
 jquery(".message .close").on("click", function () {
   jquery(this).closest(".message").transition({


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-theme/issues/286

Adds global accordion init function with accessibility features. Requires all accordions to have a `trigger`-class on the element that will open/close the accordion. 

Tested with VoiceOver on Mac.