### PR TITLE
error page: include css in the error page

### DIFF
--- a/invenio_theme/templates/semantic-ui/invenio_theme/500.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/500.html
@@ -10,8 +10,8 @@
 {% extends config.THEME_ERROR_TEMPLATE %}
 
 {% block message %}
-  <h1><i class="bolt icon"></i> {{_('Internal server error')}}</h1>
+  <h1><i class="bolt icon"></i> {{ _('Internal server error') }}</h1>
   {% if g.sentry_event_id %}
-  <p><small>{{_('Error identifier')}}: {{ g.sentry_event_id }}</small></p>
+    <p><small>{{ _('Error identifier') }}: {{ g.sentry_event_id }}</small></p>
   {% endif %}
 {% endblock message %}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page_error.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page_error.html
@@ -11,12 +11,19 @@
 {% extends config.THEME_BASE_TEMPLATE %}
 
 {% block page_body %}
-<div class="ui grid container error-page">
-<div class="ui divider hidden"></div>
-  <div class="row">
-    <div class="column">
-      {% block message %}{% endblock message %}
+  <div class="ui grid container error-page">
+    <div class="ui divider hidden"></div>
+    <div class="row">
+      <div class="column">
+        {% block message %}{% endblock message %}
+      </div>
     </div>
   </div>
-</div>
 {% endblock %}
+
+{% block css %}
+  {{ super() }}
+  {{ webpack['theme.css'] | string | safe }}
+{% endblock %}
+
+


### PR DESCRIPTION
For a still unknown reason the base theme style sheet built by flask-webpack is not being included in the jinja2 template. I managed to find a way to includes the base theme style sheet in the error page template by converting the string back into HTML.

**there is not supposed to be a question mark at the end, it is removed in the code** 


closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1565
![Screenshot from 2022-05-17 10-23-17](https://user-images.githubusercontent.com/55200060/168766822-ca64b722-e760-469a-9a2e-7df7c9325a34.png)

