### PR TITLE
overrides: add general color classes and variables

### DIFF
--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/collections/grid.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/collections/grid.overrides
@@ -18,3 +18,69 @@
     padding-top: 0px !important;
     padding-bottom: 0px !important;
 }
+
+/** Extra colors for grid, taken from ui.message **/
+.ui.grid > .row > .neutral.column,
+.ui.grid > .row > .warning.column,
+.ui.grid > .row > .negative.column,
+.ui.grid > .row > .expired.column,
+.ui.grid > .row > .positive.column {
+  margin-top: -(@rowSpacing / 2);
+  margin-bottom: -(@rowSpacing / 2);
+  padding-top: (@rowSpacing / 2);
+  padding-bottom: (@rowSpacing / 2);
+}
+
+/* Neutral */
+.ui.grid > .neutral.row,
+.ui.grid > .neutral.column,
+.ui.grid > .row > .neutral.column {
+  background-color: @neutralBackgroundColor !important;
+  color: @neutralTextColor;
+  border-radius: @defaultBorderRadius @defaultBorderRadius 0em 0em !important;
+}
+
+/* Warning */
+.ui.grid > .warning.row,
+.ui.grid > .warning.column,
+.ui.grid > .row > .warning.column {
+  background-color: @warningBackgroundColor !important;
+  color: @warningTextColor;
+  border-radius: @defaultBorderRadius @defaultBorderRadius 0em 0em !important;
+
+  .ui.button.transparent {
+    color: @warningTextColor;
+    border-color: @warningTextColor;
+
+    &:hover {
+      color: darken(@warningTextColor, 5%);
+    }
+  }
+}
+
+/* Negative */
+.ui.grid > .negative.row,
+.ui.grid > .negative.column,
+.ui.grid > .row > .negative.column {
+  background-color: @negativeBackgroundColor !important;
+  color: @negativeTextColor;
+  border-radius: @defaultBorderRadius @defaultBorderRadius 0em 0em !important;
+}
+
+/* Expired */
+.ui.grid > .expired.row,
+.ui.grid > .expired.column,
+.ui.grid > .row > .expired.column {
+  background-color: @expiredBackgroundColor !important;
+  color: @expiredTextColor;
+  border-radius: @defaultBorderRadius @defaultBorderRadius 0em 0em !important;
+}
+
+/* Positive */
+.ui.grid > .positive.row,
+.ui.grid > .positive.column,
+.ui.grid > .row > .positive.column {
+  background-color: @positiveBackgroundColor !important;
+  color: @positiveTextColor;
+  border-radius: @defaultBorderRadius @defaultBorderRadius 0em 0em !important;
+}

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/collections/grid.variables
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/collections/grid.variables
@@ -1,3 +1,9 @@
 /***********************************************
          Invenio Theme Grid Variables
 ***********************************************/
+
+@neutralBackgroundColor: #F8F8F9;
+@neutralTextColor: @textColor;
+
+@expiredBackgroundColor: @orangeBackground;
+@expiredTextColor: @orangeTextColor;

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/button.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/button.overrides
@@ -2,6 +2,7 @@
          Invenio Theme Button Overrides
 ***********************************************/
 
+
 /*--- Sign up color ---*/
 
 .ui.signup.button {
@@ -30,6 +31,7 @@
   text-shadow: @signupColorTextShadow;
 }
 
+
 /*--- Search icon button color ---*/
 
 .ui.search.button {
@@ -56,4 +58,42 @@
   background-color: @searchButtonColorDown;
   color: @searchButtonColorTextColor;
   text-shadow: @searchButtonColorTextShadow;
+}
+
+
+/*--- Warning button color ---*/
+
+.ui.warning.button {
+  background-color: @warningButtonColor;
+  color: @warningButtonTextColor;
+  text-shadow: @warningButtonTextShadow;
+  background-image: @coloredBackgroundImage;
+  box-shadow: @coloredBoxShadow;
+}
+
+.ui.warning.button:hover {
+  background-color: @warningButtonHover;
+  color: @warningButtonTextColor;
+  text-shadow: @warningButtonTextShadow;
+}
+
+.ui.warning.button:focus {
+  background-color: @warningButtonFocus;
+  color: @warningButtonTextColor;
+  text-shadow: @warningButtonTextShadow;
+}
+
+.ui.warning.button:active {
+  background-color: @warningButtonDown;
+  color: @warningButtonTextColor;
+  text-shadow: @warningButtonTextShadow;
+}
+
+
+/*--- Transparent button color ---*/
+
+.ui.button.transparent {
+  background-color: transparent;
+  color: @transparentButtonTextColor;
+  padding: 0;
 }

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/button.variables
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/button.variables
@@ -2,6 +2,9 @@
          Invenio Theme Button Variables
 ***********************************************/
 
+
+/*--- Search button color ---*/
+
 @searchButtonColor: @orange;
 @searchButtonColorHover: saturate(darken(@searchButtonColor, 5), 10, relative);
 @searchButtonColorFocus: saturate(darken(@searchButtonColor, 8), 20, relative);
@@ -14,3 +17,18 @@
 @searchButtonColorTextColor: @invertedTextColor;
 @searchButtonColorTextShadow: @invertedTextShadow;
 
+
+/*--- Warning button color ---*/
+
+@warningButtonColor: @warningColor;
+@warningButtonHover: saturate(darken(@warningButtonColor, 5), 10, relative);
+@warningButtonFocus: saturate(darken(@warningButtonColor, 8), 20, relative);
+@warningButtonDown: darken(@warningButtonColor, 10);
+@warningButtonActive: saturate(darken(@warningButtonColor, 5), 15, relative);
+@warningButtonTextColor: @invertedTextColor;
+@warningButtonTextShadow: @invertedTextShadow;
+
+
+/*--- Transparent button color ---*/
+
+@transparentButtonTextColor: @black;

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/header.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/header.overrides
@@ -19,3 +19,15 @@
 .ui.header:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6)  {
     font-size: 1em;
 }
+
+
+/*--- Negative ---*/
+.ui.negative.header {
+  color: @negativeColor !important;
+}
+a.ui.negative.header:hover {
+  color: @negativeHover !important;
+}
+.ui.negative.dividing.header {
+  border-bottom: @dividedColoredBorderWidth solid @negativeColor;
+}

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/header.variables
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/header.variables
@@ -2,3 +2,4 @@
          Invenio Theme Header Variables
 ***********************************************/
 
+@negativeHover: @redHover;

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/icon.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/icon.overrides
@@ -1,3 +1,26 @@
 /***********************************************
          Invenio Theme Icon Overrides
 ***********************************************/
+
+/* Neutral */
+i.neutral.icon {
+  color: @neutralIconColor;
+}
+
+
+/* Primary */
+i.primary.icon {
+  color: @primaryIconColor;
+}
+
+
+/* Positive */
+i.positive.icon {
+  color: @positiveIconColor;
+}
+
+
+/* Negative */
+i.negative.icon {
+  color: @negativeIconColor;
+}

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/icon.variables
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/icon.variables
@@ -4,3 +4,9 @@
 
 
 @fontPath          : '../../themes/default/assets/fonts';
+
+
+@primaryIconColor: @primaryColor;
+@neutralIconColor: @neutralColor;
+@positiveIconColor: @positiveColor;
+@negativeIconColor: @negativeColor;

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/label.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/label.overrides
@@ -1,3 +1,54 @@
 /***********************************************
          Invenio Theme Label Overrides
 ***********************************************/
+
+/*--- Neutral ---*/
+
+.ui.neutral.label {
+  background-color: @neutralLabelColor;
+  border-color: @neutralBorderLabelColor;
+  color: @neutralTextLabelColor;
+}
+
+/*--- Primary ---*/
+
+.ui.primary.label {
+  background-color: @primaryLabelColor;
+  border-color: @primaryBorderLabelColor;
+  color: @primaryTextLabelColor;
+}
+
+/*--- Positive ---*/
+
+.ui.positive.label {
+  background-color: @positiveLabelColor;
+  border-color: @positiveBorderLabelColor;
+  color: @positiveTextLabelColor;
+}
+
+
+/*--- Warning ---*/
+
+.ui.warning.label {
+  background-color: @warningLabelColor;
+  border-color: @warningBorderLabelColor;
+  color: @warningTextLabelColor;
+}
+
+
+/*--- Expired ---*/
+
+.ui.expired.label {
+  background-color: @expiredLabelColor;
+  border-color: @expiredBorderLabelColor;
+  color: @expiredTextLabelColor;
+}
+
+
+/*--- Negative ---*/
+
+.ui.negative.label {
+  background-color: @negativeLabelColor;
+  border-color: @negativeBorderLabelColor;
+  color: @negativeTextLabelColor;
+}

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/label.variables
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/label.variables
@@ -1,3 +1,44 @@
 /***********************************************
          Invenio Theme Label Variables
 ***********************************************/
+
+
+/*--- Primary ---*/
+
+@primaryLabelColor: @primaryColor;
+@primaryBorderLabelColor: @primaryColor;
+@primaryTextLabelColor: @invertedTextColor;
+
+
+/*--- Neutral ---*/
+
+@neutralLabelColor: @neutralColor;
+@neutralBorderLabelColor: @neutralColor;
+@neutralTextLabelColor: @invertedTextColor;
+
+/*--- Positive ---*/
+
+@positiveLabelColor: @positiveColor;
+@positiveBorderLabelColor: @positiveColor;
+@positiveTextLabelColor: @invertedTextColor;
+
+
+/*--- Warning ---*/
+
+@warningLabelColor: @warningColor;
+@warningBorderLabelColor: @warningColor;
+@warningTextLabelColor: @invertedTextColor;
+
+
+/*--- Expired ---*/
+
+@expiredLabelColor: @orange;
+@expiredBorderLabelColor: @orange;
+@expiredTextLabelColor: @orangeTextColor;
+
+
+/*--- Negative ---*/
+
+@negativeLabelColor: @negativeColor;
+@negativeBorderLabelColor: @negativeColor;
+@negativeTextLabelColor: @invertedTextColor;

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/segment.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/segment.overrides
@@ -7,6 +7,7 @@
     padding: 0.7em;
 }
 
+
 /* Brand */
 .ui.brand.segment:not(.inverted) {
   border-top: @coloredBorderSize solid @brandColor !important;
@@ -15,3 +16,14 @@
   background-color: @brandColor !important;
   color: @white !important;
 }
+
+
+/* Negative */
+.ui.negative.segment:not(.inverted) {
+  border-top: @coloredBorderSize solid @negativeColor;
+}
+.ui.inverted.negative.segment {
+  background-color: @negativeColor;
+  color: @white;
+}
+

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.variables
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.variables
@@ -5,20 +5,28 @@
 @defaultPadding : 2em;
 @defaultMargin  : 2em;
 
+
 /*--- Brand main colors ---*/
+
 @brandColor     : rgba(13, 95, 137, 0.8);
 
 @mutedTextColor      :  #757575;
 @textMutedColorDarken:  #4A4A4A;
 
+@neutralColor: @grey;
+
+@warningColor: @yellow;
+
 /*--- Cover page margin ---*/
 
 @coverPageDefaultMargin: 3*@defaultMargin;
+
 
 /*--- code tag color ---*/
 
 @codeColor: @pink;
 @codeBackgroundColor: lighten(@pink, 42);
+
 
 /*--- Sign up color ---*/
 
@@ -27,6 +35,7 @@
 @signupColorFocus: saturate(darken(@signupColor, 8), 20, relative);
 @signupColorDown: darken(@signupColor, 10);
 @signupColorActive: saturate(darken(@signupColor, 5), 15, relative);
+
 
 /*--- Fonts ---*/
 

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/modules/progress.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/modules/progress.overrides
@@ -1,3 +1,11 @@
 /***********************************************
          Invenio Theme Progress Overrides
 ***********************************************/
+
+/* Primary */
+.ui.primary.progress .bar {
+  background-color: @primaryColor;
+}
+.ui.primary.inverted.progress .bar {
+  background-color: @lightPrimaryColor;
+}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1503

Adds general class names for colors where colors were hard coded.

The new class names used are:
- `.warning` (rdm yellow)
- `.positive` (rdm green)
- `.negative` (rdm red)
- `.expired` (rdm orange)
- `.neutral` (rdm grey)

The following mentioned PRs are needed (see timeline).