### PR TITLE
theme: update jquery reference

### DIFF
--- a/invenio_theme/assets/semantic-ui/js/invenio_theme/theme.js
+++ b/invenio_theme/assets/semantic-ui/js/invenio_theme/theme.js
@@ -17,7 +17,7 @@ function imagePlaceholder() {
   this.src='/static/images/square-placeholder.png';
 }
 
-$(".has-placeholder").attr('onerror', imagePlaceholder);
+jquery(".has-placeholder").attr('onerror', imagePlaceholder);
 
 // Initialize Semantic UI components
 jquery(".ui.dropdown").dropdown();


### PR DESCRIPTION
The `jquery` reference was wrongly added ad `$` in one of the most recent PR's, and was giving a webpack error.

<img width="540" alt="Screenshot 2022-07-07 at 14 43 16" src="https://user-images.githubusercontent.com/21052053/177776153-4c591613-a52a-448d-816e-9fd16c5ccdbd.png">
 