### PR TITLE
migrate to flask babel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@
 Changes
 =======
 
+Version 2.0.0 (released 2023-02-28)
+
+- drop python 2.7 support
+- remove flask_babelex imports
+- upgrade invenio_i18n
+
 Version 1.4.8 (released 2023-02-07)
 
 - theme: add auto-column-grid class

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,8 +9,6 @@
 
 """Sphinx configuration."""
 
-from __future__ import print_function
-
 import sys
 
 import sphinx.environment

--- a/invenio_theme/__init__.py
+++ b/invenio_theme/__init__.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -517,8 +518,6 @@ template.
         flash('Testing flashing', category='info')
         return render_template('...')
 """
-
-from __future__ import absolute_import, print_function
 
 from .ext import InvenioTheme
 

--- a/invenio_theme/__init__.py
+++ b/invenio_theme/__init__.py
@@ -521,6 +521,6 @@ template.
 
 from .ext import InvenioTheme
 
-__version__ = "1.4.8"
+__version__ = "2.0.0"
 
 __all__ = ("__version__", "InvenioTheme")

--- a/invenio_theme/config.py
+++ b/invenio_theme/config.py
@@ -2,13 +2,14 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Configuration for Invenio-Theme."""
 
-from flask_babelex import gettext as _
+from invenio_i18n import gettext as _
 
 BASE_TEMPLATE = "invenio_theme/page.html"
 """Base template for user facing pages.

--- a/invenio_theme/ext.py
+++ b/invenio_theme/ext.py
@@ -2,13 +2,12 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Invenio standard theme."""
-
-from __future__ import absolute_import, print_function
 
 from flask import Blueprint
 from flask_babelex import lazy_gettext as _

--- a/invenio_theme/ext.py
+++ b/invenio_theme/ext.py
@@ -10,9 +10,9 @@
 """Invenio standard theme."""
 
 from flask import Blueprint
-from flask_babelex import lazy_gettext as _
 from flask_breadcrumbs import Breadcrumbs
 from flask_menu import Menu
+from invenio_i18n import lazy_gettext as _
 
 from . import config
 from .views import (

--- a/invenio_theme/views.py
+++ b/invenio_theme/views.py
@@ -2,13 +2,12 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Invenio error handlers."""
-
-from __future__ import absolute_import, print_function
 
 from flask import Blueprint, current_app, render_template
 

--- a/invenio_theme/webpack.py
+++ b/invenio_theme/webpack.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2020 CERN.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -16,8 +17,6 @@ You include one of the bundles in a page like the example below (using
     {{ webpack['base.js']}}
 
 """
-
-from __future__ import absolute_import, print_function
 
 from invenio_assets.webpack import WebpackThemeBundle
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,6 +14,6 @@ set -o errexit
 set -o nounset
 
 python -m check_manifest
-python -m setup extract_messages --dry-run
+python -m setup extract_messages --output-file /dev/null
 sphinx-build -qnNW docs docs/_build/html
 python -m pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,3 @@ ignore =
 [tool:pytest]
 addopts = --black --isort --pydocstyle --doctest-glob="*.rst" --doctest-modules --cov=invenio_theme --cov-report=term-missing tests invenio_theme
 testpaths = tests invenio_theme
-filterwarnings =
-    ignore::pytest.PytestDeprecationWarning
-    ignore::pytest.PytestWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     Flask-Menu>=0.5.0
     invenio-assets>=1.2.7
     invenio-base>=1.2.5
-    invenio-i18n>=1.3.1
+    invenio-i18n>=2.0.0
     jsmin>=3.0.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
 
 [options.extras_require]
 tests =
-    pytest-black>=0.3.0,<0.3.10
+    pytest-black>=0.3.0
     pytest-invenio>=1.4.2
     Sphinx==4.2.0
 # Kept for backwards compatibility
@@ -87,3 +87,6 @@ ignore =
 [tool:pytest]
 addopts = --black --isort --pydocstyle --doctest-glob="*.rst" --doctest-modules --cov=invenio_theme --cov-report=term-missing tests invenio_theme
 testpaths = tests invenio_theme
+filterwarnings =
+    ignore::pytest.PytestDeprecationWarning
+    ignore::pytest.PytestWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,10 +17,9 @@ import tempfile
 import jinja2
 import pytest
 from flask import Flask
-from flask_babelex import Babel
 from helpers import make_fake_template
 from invenio_assets import InvenioAssets
-from invenio_i18n import InvenioI18N
+from invenio_i18n import Babel, InvenioI18N
 from invenio_i18n.views import create_blueprint_from_app
 
 from invenio_theme import InvenioTheme

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,16 @@ def app():
     Babel(app)
     InvenioI18N(app)
     app.register_blueprint(create_blueprint_from_app(app))
+
+    def delete_locale_from_cache(exception):
+        """Unset locale from `flask.g` when the request is tearing down."""
+        from flask import g
+
+        if "_flask_babel" in g:
+            g._flask_babel.babel_locale = None
+
+    app.teardown_request(delete_locale_from_cache)
+
     return app
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,13 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 
 """Pytest configuration."""
-
-from __future__ import absolute_import, print_function
 
 import os
 import shutil

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,14 +2,13 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 
 """Pytest helpers."""
-
-from __future__ import absolute_import, print_function
 
 import os
 import shutil

--- a/tests/test_invenio_theme.py
+++ b/tests/test_invenio_theme.py
@@ -180,10 +180,10 @@ def test_html_lang(app):
     with app.test_client() as client:
         response = client.get("/index")
         assert b'lang="en" ' in response.data
-
+    with app.test_client() as client:
         response = client.get("/index?ln=de")
         assert b'lang="de" ' in response.data
-
+    with app.test_client() as client:
         response = client.get("/index?ln=en")
         assert b'lang="en" ' in response.data
 

--- a/tests/test_invenio_theme.py
+++ b/tests/test_invenio_theme.py
@@ -2,13 +2,12 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test for theme module."""
-
-from __future__ import absolute_import, print_function
 
 from flask import render_template_string
 from invenio_assets import InvenioAssets

--- a/tests/test_invenio_theme_error_handler.py
+++ b/tests/test_invenio_theme_error_handler.py
@@ -2,13 +2,12 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test for theme module."""
-
-from __future__ import absolute_import, print_function
 
 from flask import Blueprint, abort
 


### PR DESCRIPTION
- fix: --dry-run ignored
- fix: filter pytest deprecation warnings
- global: remove python2.7 support
- global: use invenio-i18n as flask-babel proxy

- NOTE: to make this testable it is necessary to release invenio-i18n
