### PR TITLE
site overrides: remove important from inline class

### DIFF
--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
@@ -271,8 +271,8 @@ code {
   display: block !important;
 }
 
-.inline{
-  display: inline !important;
+.inline {
+  display: inline;
 }
 
 /* Generator functions */


### PR DESCRIPTION
Closes https://github.com/zenodo/who-rdm/issues/23

When the `.inline` class was moved from `invenio-app-rdm` to `invenio-theme`, it also became `!important` which it was not before. This is causing an override of the SUI classes for `.inline.fields`, which is the reason for this change.

See:
`invenio-theme`, where the class became important:
- https://github.com/inveniosoftware/invenio-theme/commit/7bf5d135bd681196e2c3421f33098100ee8ac065

History of `invenio-app-rdm` where it is not important:
- https://github.com/inveniosoftware/invenio-app-rdm/blob/eb2b383c646045fc7420601d78311a7424a98432/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides#L456