### PR TITLE
add init function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@
 Changes
 =======
 
+Version 3.0.0 (released 2024-03-19)
+
+- global: remove breadcrumb support
+- global: introduce shared menu
+- global: preparation for compatibility with Flask v2.3.x deprecations
+- refactor: current_theme_icons without application context
+
 Version 2.5.10 (released 2024-01-28)
 
 - installation: fix sphinx dependency

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -319,7 +319,6 @@ intersphinx_mapping = {
     "https://docs.python.org/": None,
     "flask": ("http://flask.pocoo.org/docs/latest/", None),
     "flask_menu": ("https://flask-menu.readthedocs.io/en/latest/", None),
-    "flask_breadcrumbs": ("https://flask-breadcrumbs.readthedocs.io/en/latest/", None),
     "invenio_assets": ("https://invenio-assets.readthedocs.io/en/latest/", None),
 }
 

--- a/invenio_theme/__init__.py
+++ b/invenio_theme/__init__.py
@@ -27,7 +27,6 @@ First create a Flask application and initialize
 
 >>> from flask import Flask, render_template_string
 >>> from invenio_theme import InvenioTheme
->>> from flask_menu import register_menu
 >>> app = Flask('myapp')
 >>> theme = InvenioTheme(app)
 
@@ -421,9 +420,8 @@ Invenio-Theme defines are couple of menus that Invenio modules can plug into.
 For instance if you want to plug an menu item in the navigation bar you can do
 it like this:
 
->>> from flask_menu import register_menu
+>>> menu.submenu(".main.myitem").register("myview2", "My item", order=1)
 >>> @app.route('/myview2')
-... @register_menu(app, 'main.myitem', 'My item', order=1)
 ... def myview2():
 ...     return ""
 
@@ -459,8 +457,8 @@ Next, when creating the view register the view n the ``settings`` menu:
 
 .. code-block:: python
 
+    menu.submenu(".settings.item1").register("settings_item_1", "Item 1", order=2)
     @app.route('/settings/')
-    @register_menu(app, 'settings.item1', 'Item 1', order=2)
     def settings_item_1():
         return render_template('invenio_foo/foo_settings.html')
 

--- a/invenio_theme/__init__.py
+++ b/invenio_theme/__init__.py
@@ -15,9 +15,9 @@ Invenio-Theme mainly consits of:
   <https://getbootstrap.com/>`_ HTML, CSS and JS framework.
 - `Error handlers` - for showing user-friendly 401, 402, 404, and 500 error
   pages.
-- `Menu and breadcrumbs` - for basic site navigation using `Flask-Menu
-  <https://flask-menu.readthedocs.io/>`_ and `Flask-Breadcrumbs
-  <https://flask-breadcrumbs.readthedocs.io/>`_.
+- `Menu` - for basic site navigation using `Flask-Menu
+  <https://flask-menu.readthedocs.io/>`_
+
 
 
 Initialization
@@ -152,7 +152,7 @@ Header section template
 ~~~~~~~~~~~~~~~~~~~~~~~~
 The header template (``invenio_theme/header.html``) is reponsible for rendering
 the navigation bar (including logo, search bar, menu and login/sign up
-buttons), flash messages and the breadcrumbs.
+buttons) and flash messages
 
 Change the template by updating
 :data:`invenio_theme.config.THEME_HEADER_TEMPLATE`.
@@ -165,8 +165,6 @@ important ones are (please see the template file for full details):
 
 * ``flashmessages`` - Displays small notification messages such as
   "Successfully logged in."
-
-* ``breadcrumbs`` - Displays the breadcrumbs.
 
 Header login section template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -441,33 +439,6 @@ The following menus exists:
 
 To read more about the creation and usage of menus, see :mod:`~flask_menu`.
 
-Breadcrumbs
-~~~~~~~~~~~
-Breadcrumbs works similar to menus, just use the
-:func:`~flask_breadcrumbs.register_breadcrumb` instead.
-
->>> from flask_breadcrumbs import register_breadcrumb
-
-Using this decorator, you can specify the position of the view in a
-hierarchical manner, as well as the title in the breadcrumb. By default, the
-current breadcrumb is displayed inside the ``page_header`` block in the base
-template.
-
->>> @app.route('/part1')
-... @register_breadcrumb(app, '.', 'Index')
-... def part1():
-...     return ""
->>> @app.route('/part2')
-... @register_breadcrumb(app, '.p2', 'Part 2')
-... def part2():
-...     return ""
->>> @app.route('/part3')
-... @register_breadcrumb(app, '.p2.p3', 'Part 3')
-... def part3():
-...     return ""
-
-To learn more about the usage of breadcrumbs, see :mod:`~flask_breadcrumbs`.
-
 User settings
 ~~~~~~~~~~~~~
 If your module allows your users to configure some settings, you can provide
@@ -489,7 +460,6 @@ Next, when creating the view register the view n the ``settings`` menu:
 .. code-block:: python
 
     @app.route('/settings/')
-    @register_breadcrumb(app, '.settings', 'Settings page')
     @register_menu(app, 'settings.item1', 'Item 1', order=2)
     def settings_item_1():
         return render_template('invenio_foo/foo_settings.html')

--- a/invenio_theme/__init__.py
+++ b/invenio_theme/__init__.py
@@ -490,7 +490,6 @@ template.
 from .ext import InvenioTheme
 from .shared import menu
 
-
 __version__ = "3.0.0"
 
 

--- a/invenio_theme/__init__.py
+++ b/invenio_theme/__init__.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2024 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2024 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -490,6 +490,8 @@ template.
 from .ext import InvenioTheme
 from .shared import menu
 
-__version__ = "2.5.10"
+
+__version__ = "3.0.0"
+
 
 __all__ = ("__version__", "InvenioTheme", "menu")

--- a/invenio_theme/__init__.py
+++ b/invenio_theme/__init__.py
@@ -490,7 +490,8 @@ template.
 """
 
 from .ext import InvenioTheme
+from .shared import menu
 
 __version__ = "2.5.10"
 
-__all__ = ("__version__", "InvenioTheme")
+__all__ = ("__version__", "InvenioTheme", "menu")

--- a/invenio_theme/config.py
+++ b/invenio_theme/config.py
@@ -112,9 +112,6 @@ THEME_SEARCHBAR = True
 THEME_SEARCH_ENDPOINT = "/search"
 """The endpoint for the search bar."""
 
-THEME_BREADCRUMB_ROOT_ENDPOINT = ""
-"""The endpoint for the Home view in the breadcrumbs."""
-
 THEME_SITENAME = _("Invenio")
 """The name of the site to be used on the header and as a title."""
 

--- a/invenio_theme/ext.py
+++ b/invenio_theme/ext.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +10,6 @@
 """Invenio standard theme."""
 
 from flask import Blueprint
-from flask_breadcrumbs import Breadcrumbs
 from flask_menu import Menu
 from invenio_i18n import lazy_gettext as _
 
@@ -36,7 +35,6 @@ class InvenioTheme(object):
         """
         self.menu_ext = Menu()
         self.menu = None
-        self.breadcrumbs = Breadcrumbs()
 
         if app:
             self.init_app(app, **kwargs)
@@ -51,7 +49,6 @@ class InvenioTheme(object):
         # Initialize extensions
         self.menu_ext.init_app(app)
         self.menu = app.extensions["menu"]
-        self.breadcrumbs.init_app(app)
 
         # Register blueprint in order to register template and static folder.
         app.register_blueprint(
@@ -66,10 +63,6 @@ class InvenioTheme(object):
         # Register frontpage blueprint if enabled.
         if app.config["THEME_FRONTPAGE"]:
             app.register_blueprint(blueprint)
-
-        # Initialize breadcrumbs.
-        item = self.menu.submenu("breadcrumbs")
-        item.register(app.config["THEME_BREADCRUMB_ROOT_ENDPOINT"], _("Home"))
 
         # Register errors handlers.
         app.register_error_handler(401, unauthorized)

--- a/invenio_theme/ext.py
+++ b/invenio_theme/ext.py
@@ -10,10 +10,9 @@
 """Invenio standard theme."""
 
 from flask import Blueprint
-from flask_menu import Menu
-from invenio_i18n import lazy_gettext as _
 
 from . import config
+from .shared import menu
 from .views import (
     blueprint,
     insufficient_permissions,
@@ -33,9 +32,6 @@ class InvenioTheme(object):
         :param app: An instance of :class:`~flask.Flask`.
         :param \**kwargs: Keyword arguments are passed to ``init_app`` method.
         """
-        self.menu_ext = Menu()
-        self.menu = None
-
         if app:
             self.init_app(app, **kwargs)
 
@@ -45,10 +41,6 @@ class InvenioTheme(object):
         :param app: An instance of :class:`~flask.Flask`.
         """
         self.init_config(app)
-
-        # Initialize extensions
-        self.menu_ext.init_app(app)
-        self.menu = app.extensions["menu"]
 
         # Register blueprint in order to register template and static folder.
         app.register_blueprint(
@@ -78,6 +70,8 @@ class InvenioTheme(object):
 
             return dict(current_theme_icons=current_theme_icons)
 
+        app.context_processor(lambda: {"menu": menu})
+
         # Save reference to self on object
         app.extensions["invenio-theme"] = self
 
@@ -95,7 +89,7 @@ class InvenioTheme(object):
         # Set THEME_<name>_TEMPLATE from <name>_TEMPLATE variables if not
         # already set.
         for varname in _vars:
-            theme_varname = "THEME_{}".format(varname)
+            theme_varname = "THEME{}".format(varname)
             if app.config[theme_varname] is None:
                 app.config[theme_varname] = app.config[varname]
 

--- a/invenio_theme/ext.py
+++ b/invenio_theme/ext.py
@@ -9,20 +9,10 @@
 
 """Invenio standard theme."""
 
-from flask import Blueprint
+from flask_menu import Menu
 
 from . import config
 from .icons import ThemeIcons
-from .proxies import current_theme_icons
-from .shared import menu
-from .views import (
-    blueprint,
-    insufficient_permissions,
-    internal_error,
-    page_not_found,
-    too_many_requests,
-    unauthorized,
-)
 
 
 class InvenioTheme(object):
@@ -47,33 +37,9 @@ class InvenioTheme(object):
         """
         self.init_config(app)
 
-        # Register blueprint in order to register template and static folder.
-        app.register_blueprint(
-            Blueprint(
-                "invenio_theme",
-                __name__,
-                template_folder="templates",
-                static_folder="static",
-            )
-        )
+        self.menu_ext = Menu(app)
 
-        # Register frontpage blueprint if enabled.
-        if app.config["THEME_FRONTPAGE"]:
-            app.register_blueprint(blueprint)
-
-        # Register errors handlers.
-        app.register_error_handler(401, unauthorized)
-        app.register_error_handler(403, insufficient_permissions)
-        app.register_error_handler(404, page_not_found)
-        app.register_error_handler(429, too_many_requests)
-        app.register_error_handler(500, internal_error)
-
-        # Register context processor
-        @app.context_processor
-        def _theme_icon_ctx_processor():
-            return {"current_theme_icons": current_theme_icons}
-
-        app.context_processor(lambda: {"menu": menu})
+        app.context_processor(lambda: {"current_theme_icons": self.icons})
 
         # Save reference to self on object
         app.extensions["invenio-theme"] = self

--- a/invenio_theme/icons.py
+++ b/invenio_theme/icons.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2020 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Theme Icons."""
+
+
+class ThemeIcons:
+    """Defines names for theme icons used in CSS classes.
+
+    This class is used via the proxy ``current_theme_icons``, which initialize
+    it with the right parameters. Also, the ``current_theme_icons`` proxy is
+    automatically available in templates because it is added via a template
+    context processor.
+
+    Examples of usage:
+
+    .. code-block:: python
+
+        current_theme_icons.cogs
+        current_theme_icons['cogs']
+
+    Note, that the proxy is dependent on the Flask application context, thus
+    it can often be useful to wrap it in lazy string, to only have it evaluated
+    when needed:
+
+    .. code-block:: python
+
+        from invenio_i18n import LazyString
+        LazyString(lambda: f'<i class="{current_theme_icons.cogs}"></i>')
+    """
+
+    def __init__(self, app_themes, theme_icons):
+        """Initialize."""
+        self._app_themes = app_themes or []
+        self._theme_icons = theme_icons or {}
+
+    def __getattr__(self, name):
+        """Attribute support for getting an icon."""
+        return self.__getitem__(name)
+
+    def __getitem__(self, key):
+        """Get a icon for a specific theme."""
+        for theme in self._app_themes:
+            if theme in self._theme_icons:
+                # Icon exists for theme
+                if key in self._theme_icons[theme]:
+                    return self._theme_icons[theme][key]
+                # Pattern exists for theme
+                # If an icon is not defined we create it via a pattern -
+                # e.g. the smeantic ui pattern is ``{} icon`` and the
+                # bootstrap3 pattern is ``fa fa-{} fa-fw``.
+                elif "*" in self._theme_icons[theme]:
+                    return self._theme_icons[theme]["*"].format(key)
+        return ""

--- a/invenio_theme/proxies.py
+++ b/invenio_theme/proxies.py
@@ -11,59 +11,11 @@
 from flask import current_app
 from werkzeug.local import LocalProxy
 
+from .icons import ThemeIcons
+
 current_theme_icons = LocalProxy(
     lambda: ThemeIcons(
         current_app.config["APP_THEME"], current_app.config["THEME_ICONS"]
     )
 )
 """Proxy to the theme icon finder."""
-
-
-class ThemeIcons:
-    """Defines names for theme icons used in CSS classes.
-
-    This class is used via the proxy ``current_theme_icons``, which initialize
-    it with the right parameters. Also, the ``current_theme_icons`` proxy is
-    automatically available in templates because it is added via a template
-    context processor.
-
-    Examples of usage:
-
-    .. code-block:: python
-
-        current_theme_icons.cogs
-        current_theme_icons['cogs']
-
-    Note, that the proxy is dependent on the Flask application context, thus
-    it can often be useful to wrap it in lazy string, to only have it evaluated
-    when needed:
-
-    .. code-block:: python
-
-        from speaklater import make_lazy_string
-        make_lazy_string(lambda: f'<i class="{current_theme_icons.cogs}"></i>')
-    """
-
-    def __init__(self, app_themes, theme_icons):
-        """Initialize."""
-        self._app_themes = app_themes or []
-        self._theme_icons = theme_icons or {}
-
-    def __getattr__(self, name):
-        """Attribute support for getting an icon."""
-        return self.__getitem__(name)
-
-    def __getitem__(self, key):
-        """Get a icon for a specific theme."""
-        for theme in self._app_themes:
-            if theme in self._theme_icons:
-                # Icon exists for theme
-                if key in self._theme_icons[theme]:
-                    return self._theme_icons[theme][key]
-                # Pattern exists for theme
-                # If an icon is not defined we create it via a pattern -
-                # e.g. the smeantic ui pattern is ``{} icon`` and the
-                # bootstrap3 pattern is ``fa fa-{} fa-fw``.
-                elif "*" in self._theme_icons[theme]:
-                    return self._theme_icons[theme]["*"].format(key)
-        return ""

--- a/invenio_theme/shared.py
+++ b/invenio_theme/shared.py
@@ -8,6 +8,6 @@
 
 """Invenio standard theme."""
 
-from flask_menu.menu import MenuRoot
+from flask_menu.menu import MenuNode
 
-menu = MenuRoot("", None)
+menu = MenuNode("", None)

--- a/invenio_theme/shared.py
+++ b/invenio_theme/shared.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2023 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Invenio standard theme."""
+
+from flask_menu.menu import MenuRoot
+
+menu = MenuRoot("", None)

--- a/invenio_theme/templates/invenio_theme/admin_header.html
+++ b/invenio_theme/templates/invenio_theme/admin_header.html
@@ -21,7 +21,7 @@
     <span class="icon-bar"></span>
   </a>
   <ul class="nav navbar-nav">
-  {%- for item in menu.submenu('main').children if item.visible recursive %}
+  {%- for item in current_menu.submenu('main').children if item.visible recursive %}
     {%- if item.children -%}
         <li class="dropdown">.
           <a href="{{ item.url }}" style="display: inline-block; padding-right: 5px;"> {{ item.text|safe }} </a>
@@ -63,7 +63,7 @@
                 </div>
               </div>
             </li>
-            {%- for item in menu.submenu('settings').children if item.visible %}
+            {%- for item in current_menu.submenu('settings').children if item.visible %}
             {% if loop.first %}<li class="divider"></li>{% endif -%}
             <li><a href="{{ item.url }}">{{ item.text|safe }}</a></li>
             {%- endfor %}

--- a/invenio_theme/templates/invenio_theme/admin_header.html
+++ b/invenio_theme/templates/invenio_theme/admin_header.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2018 CERN.
+  Copyright (C) 2023 Graz University of Technology.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -20,7 +21,7 @@
     <span class="icon-bar"></span>
   </a>
   <ul class="nav navbar-nav">
-  {%- for item in current_menu.submenu('main').children if item.visible recursive %}
+  {%- for item in menu.submenu('main').children if item.visible recursive %}
     {%- if item.children -%}
         <li class="dropdown">.
           <a href="{{ item.url }}" style="display: inline-block; padding-right: 5px;"> {{ item.text|safe }} </a>
@@ -62,7 +63,7 @@
                 </div>
               </div>
             </li>
-            {%- for item in current_menu.submenu('settings').children if item.visible %}
+            {%- for item in menu.submenu('settings').children if item.visible %}
             {% if loop.first %}<li class="divider"></li>{% endif -%}
             <li><a href="{{ item.url }}">{{ item.text|safe }}</a></li>
             {%- endfor %}

--- a/invenio_theme/templates/invenio_theme/header.html
+++ b/invenio_theme/templates/invenio_theme/header.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2018 CERN.
+  Copyright (C) 2023 Graz University of Technology.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -45,7 +46,7 @@
         {%- endblock navbar_search %}
         {%- endif %}
         <ul class="nav navbar-nav">
-          {%- for item in current_menu.submenu('main').children|sort(attribute='order') if item.visible recursive %}
+          {%- for item in menu.submenu('main').children|sort(attribute='order') if item.visible recursive %}
           {%- if item.children %}
           <li class="dropdown{{ ' active' if item.active else ''}}">
             <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" href="{{ item.url }}">{{ item.text|safe }} <b class="caret"></b></a>

--- a/invenio_theme/templates/invenio_theme/header.html
+++ b/invenio_theme/templates/invenio_theme/header.html
@@ -46,7 +46,7 @@
         {%- endblock navbar_search %}
         {%- endif %}
         <ul class="nav navbar-nav">
-          {%- for item in menu.submenu('main').children|sort(attribute='order') if item.visible recursive %}
+          {%- for item in current_menu.submenu('main').children|sort(attribute='order') if item.visible recursive %}
           {%- if item.children %}
           <li class="dropdown{{ ' active' if item.active else ''}}">
             <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" href="{{ item.url }}">{{ item.text|safe }} <b class="caret"></b></a>

--- a/invenio_theme/templates/invenio_theme/header_login.html
+++ b/invenio_theme/templates/invenio_theme/header_login.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2018 CERN.
+  Copyright (C) 2023 Graz University of Technology.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -23,7 +24,7 @@
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu">
-      {%- for item in current_menu.submenu('settings').children if item.visible %}
+      {%- for item in menu.submenu('settings').children if item.visible %}
       <li><a href="{{ item.url }}">{{ item.text|safe }}</a></li>
       {%- endfor %}
       <li class="divider"></li>

--- a/invenio_theme/templates/invenio_theme/header_login.html
+++ b/invenio_theme/templates/invenio_theme/header_login.html
@@ -24,7 +24,7 @@
       <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu">
-      {%- for item in menu.submenu('settings').children if item.visible %}
+      {%- for item in current_menu.submenu('settings').children if item.visible %}
       <li><a href="{{ item.url }}">{{ item.text|safe }}</a></li>
       {%- endfor %}
       <li class="divider"></li>

--- a/invenio_theme/templates/invenio_theme/page_settings.html
+++ b/invenio_theme/templates/invenio_theme/page_settings.html
@@ -19,7 +19,7 @@
           <div class="panel panel-default">
             <div class="panel-heading"><strong>{{ _('Settings') }}</strong></div>
             <ul class="list-group">
-            {%- for item in menu.submenu('settings').children if item.visible %}
+            {%- for item in current_menu.submenu('settings').children if item.visible %}
             {%- block settings_menu_item scoped %}
               <a
                 href="{{ item.url }}"

--- a/invenio_theme/templates/invenio_theme/page_settings.html
+++ b/invenio_theme/templates/invenio_theme/page_settings.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2018 CERN.
+  Copyright (C) 2023 Graz University of Technology.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -18,7 +19,7 @@
           <div class="panel panel-default">
             <div class="panel-heading"><strong>{{ _('Settings') }}</strong></div>
             <ul class="list-group">
-            {%- for item in current_menu.submenu('settings').children if item.visible %}
+            {%- for item in menu.submenu('settings').children if item.visible %}
             {%- block settings_menu_item scoped %}
               <a
                 href="{{ item.url }}"

--- a/invenio_theme/templates/semantic-ui/invenio_theme/admin_header.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/admin_header.html
@@ -21,7 +21,7 @@
     <span class="icon-bar"></span>
   </a>
   <ul class="nav navbar-nav">
-  {%- for item in menu.submenu('main').children if item.visible recursive %}
+  {%- for item in current_menu.submenu('main').children if item.visible recursive %}
     {%- if item.children -%}
         <li class="dropdown">.
           <a href="{{ item.url }}" style="display: inline-block; padding-right: 5px;"> {{ item.text|safe }} </a>
@@ -63,7 +63,7 @@
                 </div>
               </div>
             </li>
-            {%- for item in menu.submenu('settings').children if item.visible %}
+            {%- for item in current_menu.submenu('settings').children if item.visible %}
             {% if loop.first %}<li class="divider"></li>{% endif -%}
             <li><a href="{{ item.url }}">{{ item.text|safe }}</a></li>
             {%- endfor %}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/admin_header.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/admin_header.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2018 CERN.
+  Copyright (C) 2023 Graz University of Technology.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -20,7 +21,7 @@
     <span class="icon-bar"></span>
   </a>
   <ul class="nav navbar-nav">
-  {%- for item in current_menu.submenu('main').children if item.visible recursive %}
+  {%- for item in menu.submenu('main').children if item.visible recursive %}
     {%- if item.children -%}
         <li class="dropdown">.
           <a href="{{ item.url }}" style="display: inline-block; padding-right: 5px;"> {{ item.text|safe }} </a>
@@ -62,7 +63,7 @@
                 </div>
               </div>
             </li>
-            {%- for item in current_menu.submenu('settings').children if item.visible %}
+            {%- for item in menu.submenu('settings').children if item.visible %}
             {% if loop.first %}<li class="divider"></li>{% endif -%}
             <li><a href="{{ item.url }}">{{ item.text|safe }}</a></li>
             {%- endfor %}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/header.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/header.html
@@ -55,7 +55,7 @@
               {%- endblock navbar_search %}
             {%- endif %}
           </li>
-            {%- for item in menu.submenu('main').children|sort(attribute='order') if item.visible recursive %}
+            {%- for item in current_menu.submenu('main').children|sort(attribute='order') if item.visible recursive %}
               {%- if item.children %}
               <li class="navbar-item navbar-options">
                 <div class="dropdown{{ ' active' if item.active else '' }}">

--- a/invenio_theme/templates/semantic-ui/invenio_theme/header.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/header.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2018 CERN.
+  Copyright (C) 2023 Graz University of Technology.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -54,7 +55,7 @@
               {%- endblock navbar_search %}
             {%- endif %}
           </li>
-            {%- for item in current_menu.submenu('main').children|sort(attribute='order') if item.visible recursive %}
+            {%- for item in menu.submenu('main').children|sort(attribute='order') if item.visible recursive %}
               {%- if item.children %}
               <li class="navbar-item navbar-options">
                 <div class="dropdown{{ ' active' if item.active else '' }}">

--- a/invenio_theme/templates/semantic-ui/invenio_theme/header_login.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/header_login.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2018 CERN.
+  Copyright (C) 2023 Graz University of Technology.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -31,7 +32,7 @@
         <div class="ui dropdown icon button floating">
           <i class="dropdown icon"></i>
           <div class="menu">
-            {%- for item in current_menu.submenu('settings').children if item.visible %}
+            {%- for item in menu.submenu('settings').children if item.visible %}
               <a class="item"
                 style="color:black;"
                 href="{{ item.url }}">{{ item.text|safe }}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/header_login.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/header_login.html
@@ -32,7 +32,7 @@
         <div class="ui dropdown icon button floating">
           <i class="dropdown icon"></i>
           <div class="menu">
-            {%- for item in menu.submenu('settings').children if item.visible %}
+            {%- for item in current_menu.submenu('settings').children if item.visible %}
               <a class="item"
                 style="color:black;"
                 href="{{ item.url }}">{{ item.text|safe }}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
@@ -4,6 +4,7 @@
   Copyright (C) 2015-2018 CERN.
   Copyright (C) 2021 New York University.
   Copyright (C) 2022 TU Wien.
+  Copyright (C) 2023 Graz University of Technology.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -25,7 +26,7 @@
     {%- block settings_menu scoped %}
       <div class="ui vertical menu fluid">
         <strong class="header item">{{ _('Settings') }}</strong>
-        {%- for item in current_menu.submenu('settings').children if item.visible %}
+        {%- for item in menu.submenu('settings').children if item.visible %}
 
           {%- block settings_menu_item scoped %}
             <a

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
@@ -26,7 +26,7 @@
     {%- block settings_menu scoped %}
       <div class="ui vertical menu fluid">
         <strong class="header item">{{ _('Settings') }}</strong>
-        {%- for item in menu.submenu('settings').children if item.visible %}
+        {%- for item in current_menu.submenu('settings').children if item.visible %}
 
           {%- block settings_menu_item scoped %}
             <a

--- a/invenio_theme/views.py
+++ b/invenio_theme/views.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -11,10 +11,28 @@
 
 from flask import Blueprint, current_app, render_template
 
-blueprint = Blueprint("invenio_theme_frontpage", __name__)
+
+def create_blueprint(app):
+    """Create blueprint."""
+    blueprint = Blueprint(
+        "invenio_theme_frontpage",
+        __name__,
+        template_folder="templates",
+        static_folder="static",
+    )
+
+    if app.config["THEME_FRONTPAGE"]:
+        blueprint.add_url_rule("/", "index", view_func=index)
+
+    app.register_error_handler(401, unauthorized)
+    app.register_error_handler(403, insufficient_permissions)
+    app.register_error_handler(404, page_not_found)
+    app.register_error_handler(429, too_many_requests)
+    app.register_error_handler(500, internal_error)
+
+    return blueprint
 
 
-@blueprint.route("/")
 def index():
     """Simplistic front page view."""
     return render_template(

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    Flask-Menu>=0.5.0,<1.0.0
+    Flask-Menu>=1.0.0
     invenio-assets>=1.2.7
     invenio-base>=1.2.5
     invenio-i18n>=2.0.0
@@ -46,6 +46,8 @@ invenio_assets.webpack =
     invenio_theme = invenio_theme.webpack:theme
 invenio_base.apps =
     invenio_theme = invenio_theme:InvenioTheme
+invenio_base.blueprints =
+    invenio_theme = invenio_theme.views:create_blueprint
 invenio_i18n.translations =
     messages = invenio_theme
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2024 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2024 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -27,7 +27,6 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    Flask-Breadcrumbs>=0.4.0
     Flask-Menu>=0.5.0,<1.0.0
     invenio-assets>=1.2.7
     invenio-base>=1.2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
 
 [options.extras_require]
 tests =
-    pytest-black>=0.3.0
+    pytest-black-ng>=0.4.0
     pytest-invenio>=1.4.2
     Sphinx>=5,<6
 # Kept for backwards compatibility

--- a/tests/test_invenio_theme.py
+++ b/tests/test_invenio_theme.py
@@ -187,6 +187,8 @@ def test_html_lang(app):
 def test_frontpage_not_exists(app):
     """Test the frontpage that doesn't exist."""
     # Before configure the frontpage
+    InvenioTheme(app)
+    InvenioAssets(app)
     with app.test_client() as client:
         response = client.get("/")
         assert response.status_code == 404

--- a/tests/test_invenio_theme.py
+++ b/tests/test_invenio_theme.py
@@ -143,7 +143,6 @@ def test_header_template_blocks(app):
         "brand",
         "navbar_inner",
         "navbar_right",
-        "breadcrumbs",
         "flashmessages",
         "navbar_nav",
         "navbar_search",

--- a/tests/test_invenio_theme.py
+++ b/tests/test_invenio_theme.py
@@ -34,17 +34,14 @@ def test_version():
 
 def test_init(app):
     """Initialization."""
-    theme = InvenioTheme(app)
-    assert theme.menu is not None
+    InvenioTheme(app)
     assert "THEME_SITENAME" in app.config
 
 
 def test_init_app(app):
     """Initialization."""
     theme = InvenioTheme()
-    assert theme.menu is None
     theme.init_app(app)
-    assert theme.menu is not None
     assert "THEME_SITENAME" in app.config
 
 


### PR DESCRIPTION
- introduce shared menu outside of application context
- global: refactor current_theme_icons

NOTE: it works without flask-menu and invenio-base release, BUT it works also if those are released first with flask>=3.0.0
