### PR TITLE
theme: add general styles for colored messages, on-off toggle switch,…

### DIFF
--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/collections/grid.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/collections/grid.overrides
@@ -85,6 +85,18 @@
   border-radius: @defaultBorderRadius @defaultBorderRadius 0em 0em !important;
 }
 
+/*
+  Use .stackable-tablet-mobile.row instead of .stackable.row
+  to stack content on mobile AND tablet screens
+*/
+.ui.grid > .stackable.tablet-mobile.row > .column {
+  @media screen and (max-width: @largestTabletScreen) {
+    width: 100% !important;
+    margin: 0em 0em !important;
+    box-shadow: none !important;
+    padding: 1rem 1rem !important;
+  }
+}
 
 // Administration styles
 

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/collections/message.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/collections/message.overrides
@@ -26,3 +26,23 @@
 .ui.message.code {
   overflow: auto !important;
 }
+
+.ui.message {
+
+  &.scroll-overflow {
+    overflow-x: scroll;
+  }
+
+  &.no-border-radius {
+    border-radius: 0 !important;
+  }
+
+  &.icon {
+    .small.icon {
+      font-size: @small !important;
+    }
+    .large.icon {
+      font-size: @large !important;
+    }
+  }
+}

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/header.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/header.overrides
@@ -23,11 +23,35 @@
 
 /*--- Negative ---*/
 .ui.negative.header {
-  color: @negativeColor !important;
+  color: @negativeHeaderColor !important;
 }
 a.ui.negative.header:hover {
   color: @negativeHover !important;
 }
 .ui.negative.dividing.header {
-  border-bottom: @dividedColoredBorderWidth solid @negativeColor;
+  border-bottom: @dividedColoredBorderWidth solid @negativeHeaderColor;
+}
+
+/*--- Positive ---*/
+
+.ui.positive.header {
+  color: @positiveHeaderColor !important;
+}
+a.ui.positive.header:hover {
+  color: @positiveHover !important;
+}
+.ui.positive.dividing.header {
+  border-bottom: @dividedColoredBorderWidth solid @positiveHeaderColor;
+}
+
+/*--- Warning ---*/
+
+.ui.warning.header {
+  color: @warningHeaderColor !important;
+}
+a.ui.warning.header:hover {
+  color: @warningHover !important;
+}
+.ui.warning.dividing.header {
+  border-bottom: @dividedColoredBorderWidth solid @warningHeaderColor;
 }

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/header.variables
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/header.variables
@@ -3,3 +3,10 @@
 ***********************************************/
 
 @negativeHover: @redHover;
+@positiveHover: @greenHover;
+@warningHover: @yellowHover;
+
+@positiveHeaderColor: @positiveColor;
+@negativeHeaderColor: @negativeColor;
+@neutralHeaderColor: @neutralColor;
+@warningHeaderColor: @warningColor;

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/icon.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/icon.overrides
@@ -24,3 +24,8 @@ i.positive.icon {
 i.negative.icon {
   color: @negativeIconColor;
 }
+
+/* Warning */
+i.warning-color.icon {
+  color: @warningIconColor;
+}

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/icon.variables
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/icon.variables
@@ -10,3 +10,4 @@
 @neutralIconColor: @neutralColor;
 @positiveIconColor: @positiveColor;
 @negativeIconColor: @negativeColor;
+@warningIconColor: @warningColor;

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/segment.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/segment.overrides
@@ -19,11 +19,46 @@
 
 
 /* Negative */
-.ui.negative.segment:not(.inverted) {
+.ui.negative.segment:not(.inverted):not(.left-border) {
   border-top: @coloredBorderSize solid @negativeColor;
 }
 .ui.inverted.negative.segment {
   background-color: @negativeColor;
   color: @white;
+}
+
+.ui.segment.left-border {
+
+  &.negative {
+    border-left: @coloredLeftBorderSize solid @negativeSegmentColor;
+  }
+
+  &.positive {
+    border-left: @coloredLeftBorderSize solid @positiveSegmentColor;
+  }
+
+  &.warning {
+    border-left: @coloredLeftBorderSize solid @warningSegmentColor;
+  }
+}
+
+.ui.segments {
+  &.no-border {
+    border: 0;
+  }
+
+  &.no-border-radius-top {
+    border-radius: 0 0 @borderRadius @borderRadius !important;
+  }
+
+}
+
+.ui.segment.no-border-radius {
+  border-radius: 0 !important;
+
+  &-top {
+    border-radius: 0 0 @borderRadius @borderRadius !important;
+
+  }
 }
 

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/segment.variables
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/elements/segment.variables
@@ -1,3 +1,10 @@
 /***********************************************
          Invenio Theme Segment Variables
 ***********************************************/
+
+@positiveSegmentColor: @positiveColor;
+@negativeSegmentColor: @negativeColor;
+@neutralSegmentColor: @neutralColor;
+@warningSegmentColor: @warningColor;
+
+@coloredLeftBorderSize: .45rem;

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
@@ -265,6 +265,17 @@ code {
 
   &.column {
     flex-direction: column !important;
+
+    &-mobile {
+      @media screen and (max-width: @largestMobileScreen) {
+        flex-direction: column !important;
+      }
+    }
+    &-tablet {
+      @media screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
+        flex-direction: column !important;
+      }
+    }
   }
 
   &.wrap {
@@ -468,6 +479,10 @@ code {
   justify-content: space-between;
 }
 
+.justify-center {
+  justify-content: center;
+}
+
 .align-items-start {
   align-items: start;
 }
@@ -564,5 +579,13 @@ code {
   }
   &.mini {
     font-size: @fontSize * @miniSize !important;
+  }
+}
+
+.no-style-list {
+  list-style-type: none !important;
+
+  li {
+    list-style-type: none !important;
   }
 }

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/modules/checkbox.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/modules/checkbox.overrides
@@ -39,3 +39,50 @@
 .dash:before  { content: '\e801'; }
 .plus:before { content: '\e802'; }
 */
+
+.ui.toggle.checkbox.on-off {
+  position: relative;
+
+  label {
+    position: relative;
+    height: @onOffLabelHeight;
+    padding-left: @onOffLabelWidth;
+
+    &::before {
+      content: "OFF";
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      width: @onOffLabelWidth;
+      height: @onOffLabelHeight;
+      padding: .25rem .3rem;
+      border-radius: @onOffBorderRadius;
+      color: #fff;
+      font-size: @small;
+      font-weight: 300;
+    }
+
+    &::after {
+      border-radius: @onOffBorderRadius;
+      width: @onOffToggleHeight;
+      height: @onOffToggleHeight;
+    }
+  }
+
+  input {
+    height: @onOffLabelHeight;
+
+    &:checked {
+      & ~ label {
+        &::before {
+          content: "ON";
+          text-align: left;
+        }
+
+        &:after {
+          left: (@onOffLabelWidth + .1rem) - @onOffToggleWidth;
+        }
+      }
+    }
+  }
+}

--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/modules/checkbox.variables
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/modules/checkbox.variables
@@ -1,3 +1,10 @@
 /***********************************************
          Invenio Theme Checkbox Variables
 ***********************************************/
+
+@onOffLabelHeight: 1.7rem;
+@onOffLabelWidth: 4rem;
+
+@onOffToggleHeight: 1.7rem;
+@onOffToggleWidth: 1.7rem;
+@onOffBorderRadius: .3rem;

--- a/invenio_theme/templates/invenio_theme/page_settings.html
+++ b/invenio_theme/templates/invenio_theme/page_settings.html
@@ -20,7 +20,11 @@
             <ul class="list-group">
             {%- for item in current_menu.submenu('settings').children if item.visible %}
             {%- block settings_menu_item scoped %}
-              <a href="{{ item.url }}" class="list-group-item{% if item.active %} active{% endif %}">
+              <a
+                href="{{ item.url }}"
+                class="list-group-item {% if item.active %}active{% endif %}"
+                {% if item.active %} aria-current="page" {% endif %}
+              >
                 {{ item.text|safe }}
               </a>
             {%- endblock %}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page_settings.html
@@ -13,8 +13,10 @@
 
 {%- block page_body scoped %}
 
-<div class="ui container mt-25 mb-15">
-  <h1 class="ui header">{{ _("My account") }}</h1>
+<div class="ui container fluid page-subheader-outer compact ml-0-mobile mr-0-mobile">
+  <div class="ui container page-subheader">
+    <h1 class="ui large header">{{_("My account")}}</h1>
+  </div>
 </div>
 
 <div class="ui grid container stackable">
@@ -26,7 +28,11 @@
         {%- for item in current_menu.submenu('settings').children if item.visible %}
 
           {%- block settings_menu_item scoped %}
-            <a href="{{ item.url }}" class="brand item{% if item.active %} active{% endif %}">
+            <a
+              href="{{ item.url }}"
+              class="brand item {% if item.active %}active{% endif %}"
+              {% if item.active %} aria-current="page" {% endif %}
+            >
               {{ item.text|safe }}
             </a>
           {%- endblock %}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-github/issues/115

This PR adds 
- styling for color coded headers, segments and icons
- on-off toggle switch
- some extra setting classes for `.ui.message` and `.flex.column`
- class to remove default styling from lists (useful for cases where the semantic html is needed for accessibility, but you don't want any styling)
- aligns the header styling of "My account" with the communtiies search page


See PR *pending* for screenshots