### PR TITLE
theme: Add responsive settings for auto-column-grid

### DIFF
--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
@@ -294,6 +294,10 @@ code {
   display: inline;
 }
 
+.display-grid {
+  display: grid !important;
+}
+
 /* Generator functions */
 
 .generate-margins(@max, @direction, @alias, @i: 0) when (@i =< @max) {
@@ -462,6 +466,16 @@ code {
   align-items: center;
   column-gap: 1rem;
 
+  &.no-wrap {
+    @media all and (max-width: @largestTabletScreen) {
+      grid-auto-flow: column;
+      grid-template-columns: auto max-content;
+      grid-auto-columns: max-content;
+      align-items: center;
+      column-gap: 1rem;
+    }
+  }
+
   @media all and (max-width: @largestTabletScreen) {
     grid-auto-flow: row;
     grid-template-columns: minmax(100%, 100%);
@@ -551,6 +565,10 @@ code {
 
 .half-width {
   width: 50% !important;
+}
+
+.min-width-max {
+  min-width: max-content !important;
 }
 
 .flex-direction-column {


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/171

Adds `.no-wrap` to `.auto-column-grid`, to be able to prevent unwanted wrapping on tablet & mobile screens. Used in `<CommunityCompactItem />` PR: https://github.com/inveniosoftware/invenio-communities/pull/995