### PR TITLE
Pin Flask-Menu and release v2.5.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 2.5.2 (released 2023-08-14)
+
+- installation: pin Flask-Menu to ``<v1.0.0``.
+
 Version 2.5.1 (released 2023-08-14)
 
 - theme: bugfix to decrease z-index value

--- a/invenio_theme/__init__.py
+++ b/invenio_theme/__init__.py
@@ -521,6 +521,6 @@ template.
 
 from .ext import InvenioTheme
 
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 
 __all__ = ("__version__", "InvenioTheme")

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     Flask-Breadcrumbs>=0.4.0
-    Flask-Menu>=0.5.0
+    Flask-Menu>=0.5.0,<1.0.0
     invenio-assets>=1.2.7
     invenio-base>=1.2.5
     invenio-i18n>=2.0.0


### PR DESCRIPTION
- installation: pin Flask-Menu to <1.0.0
- release: v2.5.2
