### PR TITLE
fix: build errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -316,7 +316,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "https://docs.python.org/": None,
+    "python": ("https://docs.python.org/", None),
     "flask": ("http://flask.pocoo.org/docs/latest/", None),
     "flask_menu": ("https://flask-menu.readthedocs.io/en/latest/", None),
     "flask_breadcrumbs": ("https://flask-breadcrumbs.readthedocs.io/en/latest/", None),

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2024 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -36,9 +36,9 @@ install_requires =
 
 [options.extras_require]
 tests =
-    pytest-black>=0.3.0
+    pytest-black-ng>=0.4.0
     pytest-invenio>=1.4.2
-    Sphinx==4.2.0
+    Sphinx>=5.0
 # Kept for backwards compatibility
 docs =
 


### PR DESCRIPTION
* sphinx < 5.0.0 resulted in an error in python3.9

* due to sphinx >= 5.0 a warning popep up in docs/conf.py which was
  fixed

* update pytest-black to pytest-black-ng to overcome the BlackItem
  DeprecationWarning
