### PR TITLE
Revert "global: remove breadcrumbs"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -319,6 +319,7 @@ intersphinx_mapping = {
     "https://docs.python.org/": None,
     "flask": ("http://flask.pocoo.org/docs/latest/", None),
     "flask_menu": ("https://flask-menu.readthedocs.io/en/latest/", None),
+    "flask_breadcrumbs": ("https://flask-breadcrumbs.readthedocs.io/en/latest/", None),
     "invenio_assets": ("https://invenio-assets.readthedocs.io/en/latest/", None),
 }
 

--- a/invenio_theme/__init__.py
+++ b/invenio_theme/__init__.py
@@ -15,9 +15,9 @@ Invenio-Theme mainly consits of:
   <https://getbootstrap.com/>`_ HTML, CSS and JS framework.
 - `Error handlers` - for showing user-friendly 401, 402, 404, and 500 error
   pages.
-- `Menu` - for basic site navigation using `Flask-Menu
-  <https://flask-menu.readthedocs.io/>`_
-
+- `Menu and breadcrumbs` - for basic site navigation using `Flask-Menu
+  <https://flask-menu.readthedocs.io/>`_ and `Flask-Breadcrumbs
+  <https://flask-breadcrumbs.readthedocs.io/>`_.
 
 
 Initialization
@@ -151,7 +151,7 @@ Header section template
 ~~~~~~~~~~~~~~~~~~~~~~~~
 The header template (``invenio_theme/header.html``) is reponsible for rendering
 the navigation bar (including logo, search bar, menu and login/sign up
-buttons) and flash messages
+buttons), flash messages and the breadcrumbs.
 
 Change the template by updating
 :data:`invenio_theme.config.THEME_HEADER_TEMPLATE`.
@@ -164,6 +164,8 @@ important ones are (please see the template file for full details):
 
 * ``flashmessages`` - Displays small notification messages such as
   "Successfully logged in."
+
+* ``breadcrumbs`` - Displays the breadcrumbs.
 
 Header login section template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -437,6 +439,33 @@ The following menus exists:
 
 To read more about the creation and usage of menus, see :mod:`~flask_menu`.
 
+Breadcrumbs
+~~~~~~~~~~~
+Breadcrumbs works similar to menus, just use the
+:func:`~flask_breadcrumbs.register_breadcrumb` instead.
+
+>>> from flask_breadcrumbs import register_breadcrumb
+
+Using this decorator, you can specify the position of the view in a
+hierarchical manner, as well as the title in the breadcrumb. By default, the
+current breadcrumb is displayed inside the ``page_header`` block in the base
+template.
+
+>>> @app.route('/part1')
+... @register_breadcrumb(app, '.', 'Index')
+... def part1():
+...     return ""
+>>> @app.route('/part2')
+... @register_breadcrumb(app, '.p2', 'Part 2')
+... def part2():
+...     return ""
+>>> @app.route('/part3')
+... @register_breadcrumb(app, '.p2.p3', 'Part 3')
+... def part3():
+...     return ""
+
+To learn more about the usage of breadcrumbs, see :mod:`~flask_breadcrumbs`.
+
 User settings
 ~~~~~~~~~~~~~
 If your module allows your users to configure some settings, you can provide
@@ -459,6 +488,8 @@ Next, when creating the view register the view n the ``settings`` menu:
 
     menu.submenu(".settings.item1").register("settings_item_1", "Item 1", order=2)
     @app.route('/settings/')
+    @register_breadcrumb(app, '.settings', 'Settings page')
+    @register_menu(app, 'settings.item1', 'Item 1', order=2)
     def settings_item_1():
         return render_template('invenio_foo/foo_settings.html')
 

--- a/invenio_theme/config.py
+++ b/invenio_theme/config.py
@@ -112,6 +112,9 @@ THEME_SEARCHBAR = True
 THEME_SEARCH_ENDPOINT = "/search"
 """The endpoint for the search bar."""
 
+THEME_BREADCRUMB_ROOT_ENDPOINT = ""
+"""The endpoint for the Home view in the breadcrumbs."""
+
 THEME_SITENAME = _("Invenio")
 """The name of the site to be used on the header and as a title."""
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     Flask-Menu>=1.0.0
+    Flask-Breadcrumbs>=0.4.0
     invenio-assets>=1.2.7
     invenio-base>=1.2.5
     invenio-i18n>=2.0.0

--- a/tests/test_invenio_theme.py
+++ b/tests/test_invenio_theme.py
@@ -140,6 +140,7 @@ def test_header_template_blocks(app):
         "brand",
         "navbar_inner",
         "navbar_right",
+        "breadcrumbs",
         "flashmessages",
         "navbar_nav",
         "navbar_search",


### PR DESCRIPTION
This reverts commit 1cec8367f2b96dcfee3341a18630cee805ca03be.

Flask-breadcrumbs is still being used all around invenio, see: https://github.com/search?q=org%3Ainveniosoftware+flask_breadcrumbs&type=code
