### PR TITLE
templates: add meta robot tags

### DIFF
--- a/invenio_theme/config.py
+++ b/invenio_theme/config.py
@@ -91,6 +91,26 @@ THEME_GENERATOR = "Invenio"
 Accepts a string or a func returning a string. Set it to `None` to disable it.
 """
 
+THEME_META_ROBOT_TAGS = []
+"""Robots meta tag to control indexing of the page.
+
+Accepts a list of dicts that will be converted into meta tag attributes, e.g.:
+
+.. code-block:: python
+
+    THEME_META_ROBOT_TAGS = [
+        {"name": "robots", "content": "noindex, nofollow"},
+        {"name": "googlebot", "content": "noimageindex"},
+    ]
+
+will generate:
+
+.. code-block:: html
+
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="googlebot" content="noimageindex">
+"""
+
 THEME_GOOGLE_SITE_VERIFICATION = []
 """List of Google Site Verification tokens to be used.
 

--- a/invenio_theme/templates/invenio_theme/page.html
+++ b/invenio_theme/templates/invenio_theme/page.html
@@ -14,17 +14,27 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
     {%- if description %}<meta name="description" content="{{ description }}" />{% endif %}
     {%- if keywords %}<meta name="keywords" content="{{ keywords }}" />{% endif %}
+
     {%- if config.get('THEME_GOOGLE_SITE_VERIFICATION', None) %}
       {%- for google_id in config.THEME_GOOGLE_SITE_VERIFICATION %}
     <meta name="google-site-verification" content="{{google_id}}"/>
       {%- endfor %}
     {%- endif %}
+
     {% set meta_generator = get_meta_generator() %}
     {% if meta_generator %}
     <meta name="generator" content="{{ meta_generator }}"/>
     {%- endif %}
+
+    {# Add meta tags from an existing "meta_robot_tags" Jinja variable or config #}
+    {% set meta_robot_tags = meta_robot_tags or config.get("THEME_META_ROBOT_TAGS") %}
+    {% for meta_tag in meta_robot_tags %}
+      <meta {{ meta_tag | xmlattr }}>
+    {% endfor %}
+
     {%- endblock head_meta %}
     {%- block head_title %}
     {%- set title = title or _(config.THEME_SITENAME) or _('Invenio') %}

--- a/invenio_theme/templates/semantic-ui/invenio_theme/page.html
+++ b/invenio_theme/templates/semantic-ui/invenio_theme/page.html
@@ -16,17 +16,27 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
     {%- if description %}<meta name="description" content="{{ description }}" />{% endif %}
     {%- if keywords %}<meta name="keywords" content="{{ keywords }}" />{% endif %}
+
     {%- if config.get('THEME_GOOGLE_SITE_VERIFICATION', None) %}
       {%- for google_id in config.THEME_GOOGLE_SITE_VERIFICATION %}
     <meta name="google-site-verification" content="{{google_id}}"/>
       {%- endfor %}
     {%- endif %}
+
     {% set meta_generator = get_meta_generator() %}
     {% if meta_generator %}
     <meta name="generator" content="{{ meta_generator }}"/>
     {%- endif %}
+
+    {# Add meta tags from an existing "meta_robot_tags" Jinja variable or config #}
+    {% set meta_robot_tags = meta_robot_tags or config.get("THEME_META_ROBOT_TAGS") %}
+    {% for meta_tag in meta_robot_tags %}
+      <meta {{ meta_tag | xmlattr }}>
+    {% endfor %}
+
     {%- endblock head_meta %}
 
     {%- block head_title %}


### PR DESCRIPTION
* Closes https://github.com/zenodo/zenodo-rdm/issues/951.
* Generate robots meta tags from the `THEME_META_ROBOT_TAGS` config or
  exlicitly set via the `meta_robot_tags` Jinja variable.
