### PR TITLE
navbar: update logo size in non-desktop devices

### DIFF
--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/navbar/navbar.less
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/navbar/navbar.less
@@ -168,7 +168,7 @@ ul.navbar-menu:not(.active) {
   }
 }
 
-@media all and (min-width: 1200px) {
+@media all and (min-width: 1300px) {
   .logo {
     width: 250px;
     margin-right: 20px;


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> The behavior described and updated in this PR was identified in InvenioRDM v12 with invenio-theme version `3.3.0`

The navbar logo size does not adjust immediately when transitioning from the `computer` to `tablet` breakpoint (`1300px`). It changes only when the page width is below `1200px`. The GIF below demonstrates this behavior.

![issue-01](https://github.com/user-attachments/assets/c4371f5e-30d9-494b-93c2-9863184b03cd)

This PR fixes this behavior by updating the image media query, ensuring the logo size changes consistently at the appropriate breakpoint. The GIF below presents the result of the proposed modification.

![issue-02](https://github.com/user-attachments/assets/63c89210-6689-4c59-bccd-4100932733b8)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [X] I've added relevant test cases.
- [X] I've added relevant documentation.
- [X] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [X] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [X] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [X] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [X] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
