### PR TITLE
fix: ModuleWarning: Deprecation Warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,18 @@
 ..
     This file is part of Invenio.
     Copyright (C) 2015-2025 CERN.
-    Copyright (C) 2024 Graz University of Technology.
+    Copyright (C) 2024-2025 Graz University of Technology.
 
     Invenio is free software; you can redistribute it and/or modify it
     under the terms of the MIT License; see LICENSE file for more details.
 
 Changes
 =======
+
+Version unreleased
+
+- fix: ModuleWarning: Deprecation Warning
+
 Version v4.1.0 (released 2025-01-20)
 
 - theme: expand generator classes

--- a/invenio_theme/assets/semantic-ui/scss/invenio_theme/admin.scss
+++ b/invenio_theme/assets/semantic-ui/scss/invenio_theme/admin.scss
@@ -6,9 +6,9 @@
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
-@import "~admin-lte/dist/css/AdminLTE";
-@import "~admin-lte/dist/css/skins/skin-blue";
-@import "~select2/dist/css/select2";
+@use "~admin-lte/dist/css/AdminLTE";
+@use "~admin-lte/dist/css/skins/skin-blue";
+@use "~select2/dist/css/select2";
 
 .main-header {
   background-color: #2c3e50;


### PR DESCRIPTION
* Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
  More info and automated migrator: https://sass-lang.com/d/import
