### PR TITLE
app: register error handling in finalize + config for api_apps

### DIFF
--- a/invenio_theme/ext.py
+++ b/invenio_theme/ext.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
 # Copyright (C) 2022-2023 Graz University of Technology.
+# Copyright (C) 2025 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,6 +15,13 @@ from invenio_base.utils import load_or_import_from_config
 
 from . import config
 from .icons import ThemeIcons
+from .views import (
+    insufficient_permissions,
+    internal_error,
+    page_not_found,
+    too_many_requests,
+    unauthorized,
+)
 
 
 class InvenioTheme(object):
@@ -37,6 +45,7 @@ class InvenioTheme(object):
         :param app: An instance of :class:`~flask.Flask`.
         """
         self.init_config(app)
+        self.register_error_handlers(app)
 
         self.menu_ext = Menu(app)
 
@@ -71,6 +80,14 @@ class InvenioTheme(object):
             return value() if callable(value) else value
 
         app.jinja_env.globals["get_meta_generator"] = _generator_func_or_str
+
+    def register_error_handlers(self, app):
+        """Register error handlers."""
+        app.register_error_handler(401, unauthorized)
+        app.register_error_handler(403, insufficient_permissions)
+        app.register_error_handler(404, page_not_found)
+        app.register_error_handler(429, too_many_requests)
+        app.register_error_handler(500, internal_error)
 
     @property
     def icons(self):

--- a/invenio_theme/views.py
+++ b/invenio_theme/views.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
 # Copyright (C) 2022-2023 Graz University of Technology.
+# Copyright (C) 2025 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -23,12 +24,6 @@ def create_blueprint(app):
 
     if app.config["THEME_FRONTPAGE"]:
         blueprint.add_url_rule("/", "index", view_func=index)
-
-    app.register_error_handler(401, unauthorized)
-    app.register_error_handler(403, insufficient_permissions)
-    app.register_error_handler(404, page_not_found)
-    app.register_error_handler(429, too_many_requests)
-    app.register_error_handler(500, internal_error)
 
     return blueprint
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.


### PR DESCRIPTION
*new*

Moved the error handling registration out of finalize_app (and still out of blueprint) into app loading. Left alone registration of a new `invenio_base.api_apps` app in the end. Repos are adding THEME_FRONTPAGE to their conftest and I'd rather not introduce more wide-spanning changes than necessary. Just 1 commit, so ready for review + merge.

*old*
~~- Move error handling to `finalize_app`~~
~~- Create a different ext instance in order to load config in an API app~~

~~The second point solves the failing tests using `create_api` across repos, but could also be solved on a repo by repo basis and setting `"THEME_FRONTPAGE"` in each test's app_config.~~