### PR TITLE
theme: move styles from invenio-app-rdm to invenio-theme

### DIFF
--- a/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
+++ b/invenio_theme/assets/semantic-ui/less/invenio_theme/theme/globals/site.overrides
@@ -667,3 +667,38 @@ blockquote{
 .font-style-italic {
   font-style: italic;
 }
+
+:not(.ui.grid).only {
+
+  &.mobile:not(.tablet) {
+    @media all and (min-width: @tabletBreakpoint) {
+      display: none !important;
+    }
+  }
+
+  &.tablet {
+    &.mobile {
+      @media all and (min-width: @computerBreakpoint) {
+        display: none !important;
+      }
+    }
+
+    &.computer {
+      @media all and (max-width: @largestMobileScreen) {
+        display: none !important;
+      }
+    }
+
+    &:not(.computer):not(.mobile) {
+      @media not all and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
+        display: none !important;
+      }
+    }
+  }
+
+  &.computer:not(.tablet) {
+    @media all and (max-width: @largestTabletScreen) {
+      display: none !important;
+    }
+  }
+}


### PR DESCRIPTION
invenio-administration depends on the moved styles 
Thus we move them from invenio-app-rdm to invenio-theme

see: https://github.com/inveniosoftware/invenio-app-rdm/pull/3126


closes: https://github.com/CERNDocumentServer/cds-ils/issues/1006