### PR TITLE
Fix the publication workflow by using the new catalog compilation step

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -11,3 +11,4 @@ jobs:
     secrets: inherit
     with:
       babel-compile-catalog: true
+      backend-package-path: invenio_theme

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 Changes
 =======
 
+Version v5.0.2 (released 2026-07-01)
+
+- fix(publish): use the appropriate translation step in the publication workflow
+
 Version v5.0.1 (released 2026-07-01)
 
 - chore(setup): migrate build backend from setuptools to hatchling

--- a/invenio_theme/__init__.py
+++ b/invenio_theme/__init__.py
@@ -486,7 +486,7 @@ template.
 from .ext import InvenioTheme
 from .shared import menu
 
-__version__ = "5.0.1"
+__version__ = "5.0.2"
 
 
 __all__ = ("__version__", "InvenioTheme", "menu")


### PR DESCRIPTION
Fix the publication workflow by using the appropriate translation catalog compilation step.
The new step was introduced here: https://github.com/inveniosoftware/workflows/pull/30